### PR TITLE
[Add] DrinkSelectHorizontalScrollBar 작성 #9

### DIFF
--- a/FinalHrmiProjects.xcodeproj/project.pbxproj
+++ b/FinalHrmiProjects.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		09CDADA52B6171C6007E51B1 /* DrinkSelectHorizontalScrollBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09CDADA42B6171C6007E51B1 /* DrinkSelectHorizontalScrollBar.swift */; };
 		B121A5722B5F8EE100667D42 /* Font +.swift in Sources */ = {isa = PBXBuildFile; fileRef = B121A5712B5F8EE100667D42 /* Font +.swift */; };
 		B121A5732B5F910900667D42 /* Pretendard-Bold.otf in Resources */ = {isa = PBXBuildFile; fileRef = B121A56C2B5F8D5D00667D42 /* Pretendard-Bold.otf */; };
 		B121A5742B5F910B00667D42 /* Pretendard-Light.otf in Resources */ = {isa = PBXBuildFile; fileRef = B121A56D2B5F8D5D00667D42 /* Pretendard-Light.otf */; };
@@ -43,6 +44,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		09CDADA42B6171C6007E51B1 /* DrinkSelectHorizontalScrollBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrinkSelectHorizontalScrollBar.swift; sourceTree = "<group>"; };
 		B121A5692B5F8D5D00667D42 /* Pretendard-Regular.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Regular.otf"; sourceTree = "<group>"; };
 		B121A56A2B5F8D5D00667D42 /* Pretendard-SemiBold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-SemiBold.otf"; sourceTree = "<group>"; };
 		B121A56B2B5F8D5D00667D42 /* Pretendard-Medium.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Medium.otf"; sourceTree = "<group>"; };
@@ -307,6 +309,7 @@
 			isa = PBXGroup;
 			children = (
 				B1EE24A42B614872007F68B0 /* SearchBar.swift */,
+				09CDADA42B6171C6007E51B1 /* DrinkSelectHorizontalScrollBar.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -407,6 +410,7 @@
 				B1EE24982B6144BD007F68B0 /* LikedViewModel.swift in Sources */,
 				B1EE24962B6144A5007F68B0 /* MypageViewModel.swift in Sources */,
 				B1EE24922B61447F007F68B0 /* MainView.swift in Sources */,
+				09CDADA52B6171C6007E51B1 /* DrinkSelectHorizontalScrollBar.swift in Sources */,
 				B1EE24A02B6144E3007F68B0 /* MainViewModel.swift in Sources */,
 				B1EE248C2B61446A007F68B0 /* RecordView.swift in Sources */,
 				B1B8FE7D2B5EA9D900921BBE /* FinalHrmiProjectsApp.swift in Sources */,

--- a/FinalHrmiProjects/FinalHrmiProjectsApp.swift
+++ b/FinalHrmiProjects/FinalHrmiProjectsApp.swift
@@ -8,18 +8,18 @@
 import SwiftUI
 import FirebaseCore
 
-class AppDelegate: NSObject, UIApplicationDelegate {
-  func application(_ application: UIApplication,
-                   didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
-    FirebaseApp.configure()
-
-    return true
-  }
-}
+//class AppDelegate: NSObject, UIApplicationDelegate {
+//  func application(_ application: UIApplication,
+//                   didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
+//    FirebaseApp.configure()
+//
+//    return true
+//  }
+//}
 
 @main
 struct FinalHrmiProjectsApp: App {
-    @UIApplicationDelegateAdaptor(AppDelegate.self) var delegate
+//    @UIApplicationDelegateAdaptor(AppDelegate.self) var delegate
     var body: some Scene {
         WindowGroup {
             ContentView()

--- a/FinalHrmiProjects/Resource/Components/DrinkSelectHorizontalScrollBar.swift
+++ b/FinalHrmiProjects/Resource/Components/DrinkSelectHorizontalScrollBar.swift
@@ -22,9 +22,8 @@ struct DrinkSelectHorizontalScrollBar: View {
                 ForEach(0..<typesOfDrink.count, id: \.self) { index in
                     // 술 종류
                     Text(typesOfDrink[index])
-                        .font(.system(size: 16))
-                        .fontWeight(index == selectedDrinkIndex ? .semibold : .medium)
-                        .foregroundStyle(index == selectedDrinkIndex ? Color.black : Color.gray)
+                        .font(index == selectedDrinkIndex ? .semibold16 : .medium16)
+                        .foregroundStyle(index == selectedDrinkIndex ? Color.mainBlack : Color.gray01)
                         .onTapGesture {
                             selectedDrinkIndex = index
                         }

--- a/FinalHrmiProjects/Resource/Components/DrinkSelectHorizontalScrollBar.swift
+++ b/FinalHrmiProjects/Resource/Components/DrinkSelectHorizontalScrollBar.swift
@@ -23,7 +23,7 @@ struct DrinkSelectHorizontalScrollBar: View {
                     // 술 종류
                     Text(typesOfDrink[index])
                         .font(index == selectedDrinkIndex ? .semibold16 : .medium16)
-                        .foregroundStyle(index == selectedDrinkIndex ? Color.mainBlack : Color.gray01)
+                        .foregroundStyle(index == selectedDrinkIndex ? .mainBlack : .gray01)
                         .onTapGesture {
                             selectedDrinkIndex = index
                         }

--- a/FinalHrmiProjects/Resource/Components/DrinkSelectHorizontalScrollBar.swift
+++ b/FinalHrmiProjects/Resource/Components/DrinkSelectHorizontalScrollBar.swift
@@ -1,0 +1,43 @@
+//
+//  DrinkSelectHorizontalScrollBar.swift
+//  FinalHrmiProjects
+//
+//  Created by phang on 1/25/24.
+//
+
+import SwiftUI
+
+struct DrinkSelectHorizontalScrollBar: View {
+    // UITest - Drink 종류 DummyData
+    private let typesOfDrink = [
+        "전체", "우리술", "맥주", "위스키", "와인", "브랜디", "리큐르", "럼", "사케", "기타"
+    ]
+    // UITest - Drink 종류 DummyData
+    @State private var selectedDrinkIndex = 0
+    
+    var body: some View {
+        // 가로 스크롤
+        ScrollView(.horizontal) {
+            HStack(alignment: .center, spacing: 20) {
+                ForEach(0..<typesOfDrink.count, id: \.self) { index in
+                    // 술 종류
+                    Text(typesOfDrink[index])
+                        .font(.system(size: 16))
+                        .fontWeight(index == selectedDrinkIndex ? .semibold : .medium)
+                        .foregroundStyle(index == selectedDrinkIndex ? Color.black : Color.gray)
+                        .onTapGesture {
+                            selectedDrinkIndex = index
+                        }
+                }
+            }
+        }
+        // 스크롤 인디케이터 X
+        .scrollIndicators(.hidden)
+        .padding(20)
+        .frame(maxWidth: .infinity)
+    }
+}
+
+#Preview {
+    DrinkSelectHorizontalScrollBar()
+}


### PR DESCRIPTION
## 개요 (이슈 번호 및 요약)
- DrinkInfoView 에서 사용될 술 종류 고르는 가로스크롤바 제작
- close #9

## 변경 사항 (작업 내용)
- 현재는 술 종류 [전체 / 우리술 / 맥주 / 위스키 / 와인 / 브랜디 / 리큐르 / 럼 / 사케 / 기타] 로 더미데이터 사용 (추후 수정 예정)
- 버튼 사용 안하고, onTapGesture 사용
(버튼 사용 시, 살짝 깜빡거리는 애니메이션이 어울리지 않는다고 생각되어 onTapGesture 사용)

## 스크린샷
![스크린샷 2024-01-25 오전 1 27 30](https://github.com/APP-iOS3rd/PJ4T7_HrMi/assets/109324421/68c68b03-a629-469f-a1fb-0f8b82c80ca5)

## 특이사항 (트러블 슈팅 과정 및 참고 자료 등)
