### PR TITLE
[Add] PostDetailView UI 구현 #37

### DIFF
--- a/FinalHrmiProjects.xcodeproj/project.pbxproj
+++ b/FinalHrmiProjects.xcodeproj/project.pbxproj
@@ -7,12 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		096E63182B616886009246CE /* DrinkListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 096E63172B616886009246CE /* DrinkListCell.swift */; };
-		096E631A2B616F31009246CE /* DrinkGridCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 096E63192B616F31009246CE /* DrinkGridCell.swift */; };
-		09CDADA52B6171C6007E51B1 /* DrinkSelectHorizontalScrollBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09CDADA42B6171C6007E51B1 /* DrinkSelectHorizontalScrollBar.swift */; };
-		2C2FF2982B63916700B2301A /* StarRating.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C2FF2972B63916700B2301A /* StarRating.swift */; };
-		7B904C662B6168C60052384A /* PostCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B904C652B6168C60052384A /* PostCell.swift */; };
-		7B904C682B6184560052384A /* CustomTextSegment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B904C672B6184560052384A /* CustomTextSegment.swift */; };
 		0914DEAD2B66453E0014E102 /* PagerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0914DEAC2B66453E0014E102 /* PagerView.swift */; };
 		09254CA72B637C9900569D94 /* CustomDivider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09254CA62B637C9900569D94 /* CustomDivider.swift */; };
 		0961B7972B6624D300A9F553 /* DrinkInfoList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0961B7962B6624D300A9F553 /* DrinkInfoList.swift */; };
@@ -21,8 +15,15 @@
 		096E631A2B616F31009246CE /* DrinkGridCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 096E63192B616F31009246CE /* DrinkGridCell.swift */; };
 		09CDADA52B6171C6007E51B1 /* DrinkSelectHorizontalScrollBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09CDADA42B6171C6007E51B1 /* DrinkSelectHorizontalScrollBar.swift */; };
 		2C2044E82B63B9D600773266 /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C2044E72B63B9D600773266 /* RootView.swift */; };
+		2C2FF2982B63916700B2301A /* StarRating.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C2FF2972B63916700B2301A /* StarRating.swift */; };
 		2C63DD522B676E1000770E3A /* TabItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C63DD512B676E1000770E3A /* TabItem.swift */; };
 		7B6D76A72B677A8F00601B55 /* Button.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B6D76A62B677A8F00601B55 /* Button.swift */; };
+		7B6D76AB2B67CE3D00601B55 /* PostDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B6D76AA2B67CE3D00601B55 /* PostDetailView.swift */; };
+		7B6D76AD2B67CE6500601B55 /* Handler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B6D76AC2B67CE6500601B55 /* Handler.swift */; };
+		7B6D76AF2B67CFC900601B55 /* PostInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B6D76AE2B67CFC900601B55 /* PostInfo.swift */; };
+		7B6D76B12B67D1E100601B55 /* PostPhotoScroll.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B6D76B02B67D1E100601B55 /* PostPhotoScroll.swift */; };
+		7B6D76B32B67D3B700601B55 /* PostDrinkRating.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B6D76B22B67D3B700601B55 /* PostDrinkRating.swift */; };
+		7B6D76B52B67D5F900601B55 /* PostTags.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B6D76B42B67D5F900601B55 /* PostTags.swift */; };
 		7B904C662B6168C60052384A /* PostCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B904C652B6168C60052384A /* PostCell.swift */; };
 		7B904C682B6184560052384A /* CustomTextSegment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B904C672B6184560052384A /* CustomTextSegment.swift */; };
 		AC1FEAAE2B639781006E9E65 /* CustomAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC1FEAAD2B639781006E9E65 /* CustomAlert.swift */; };
@@ -68,12 +69,6 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		096E63172B616886009246CE /* DrinkListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrinkListCell.swift; sourceTree = "<group>"; };
-		096E63192B616F31009246CE /* DrinkGridCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrinkGridCell.swift; sourceTree = "<group>"; };
-		09CDADA42B6171C6007E51B1 /* DrinkSelectHorizontalScrollBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrinkSelectHorizontalScrollBar.swift; sourceTree = "<group>"; };
-		2C2FF2972B63916700B2301A /* StarRating.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StarRating.swift; sourceTree = "<group>"; };
-		7B904C652B6168C60052384A /* PostCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostCell.swift; sourceTree = "<group>"; };
-		7B904C672B6184560052384A /* CustomTextSegment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomTextSegment.swift; sourceTree = "<group>"; };
 		0914DEAC2B66453E0014E102 /* PagerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PagerView.swift; sourceTree = "<group>"; };
 		09254CA62B637C9900569D94 /* CustomDivider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomDivider.swift; sourceTree = "<group>"; };
 		0961B7962B6624D300A9F553 /* DrinkInfoList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrinkInfoList.swift; sourceTree = "<group>"; };
@@ -82,8 +77,15 @@
 		096E63192B616F31009246CE /* DrinkGridCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrinkGridCell.swift; sourceTree = "<group>"; };
 		09CDADA42B6171C6007E51B1 /* DrinkSelectHorizontalScrollBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrinkSelectHorizontalScrollBar.swift; sourceTree = "<group>"; };
 		2C2044E72B63B9D600773266 /* RootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootView.swift; sourceTree = "<group>"; };
+		2C2FF2972B63916700B2301A /* StarRating.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StarRating.swift; sourceTree = "<group>"; };
 		2C63DD512B676E1000770E3A /* TabItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabItem.swift; sourceTree = "<group>"; };
 		7B6D76A62B677A8F00601B55 /* Button.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Button.swift; sourceTree = "<group>"; };
+		7B6D76AA2B67CE3D00601B55 /* PostDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostDetailView.swift; sourceTree = "<group>"; };
+		7B6D76AC2B67CE6500601B55 /* Handler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Handler.swift; sourceTree = "<group>"; };
+		7B6D76AE2B67CFC900601B55 /* PostInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostInfo.swift; sourceTree = "<group>"; };
+		7B6D76B02B67D1E100601B55 /* PostPhotoScroll.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostPhotoScroll.swift; sourceTree = "<group>"; };
+		7B6D76B22B67D3B700601B55 /* PostDrinkRating.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostDrinkRating.swift; sourceTree = "<group>"; };
+		7B6D76B42B67D5F900601B55 /* PostTags.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostTags.swift; sourceTree = "<group>"; };
 		7B904C652B6168C60052384A /* PostCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostCell.swift; sourceTree = "<group>"; };
 		7B904C672B6184560052384A /* CustomTextSegment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomTextSegment.swift; sourceTree = "<group>"; };
 		AC1FEAAD2B639781006E9E65 /* CustomAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomAlert.swift; sourceTree = "<group>"; };
@@ -159,6 +161,7 @@
 				B158F83E2B657A9000E33C47 /* Theme.swift */,
 				B1EE24A32B614508007F68B0 /* Components */,
 				B121A5682B5F8D4800667D42 /* Pretendard */,
+				7B6D76AC2B67CE6500601B55 /* Handler.swift */,
 			);
 			path = Resource;
 			sourceTree = "<group>";
@@ -285,6 +288,11 @@
 			isa = PBXGroup;
 			children = (
 				B1EE248D2B614470007F68B0 /* PostsView.swift */,
+				7B6D76AA2B67CE3D00601B55 /* PostDetailView.swift */,
+				7B6D76AE2B67CFC900601B55 /* PostInfo.swift */,
+				7B6D76B02B67D1E100601B55 /* PostPhotoScroll.swift */,
+				7B6D76B22B67D3B700601B55 /* PostDrinkRating.swift */,
+				7B6D76B42B67D5F900601B55 /* PostTags.swift */,
 			);
 			path = Posts;
 			sourceTree = "<group>";
@@ -479,8 +487,11 @@
 				2C2FF2982B63916700B2301A /* StarRating.swift in Sources */,
 				B1EE248A2B614464007F68B0 /* LikedView.swift in Sources */,
 				B127A4222B64EB53001F005D /* CustomBottomSheet.swift in Sources */,
+				7B6D76B32B67D3B700601B55 /* PostDrinkRating.swift in Sources */,
+				7B6D76B12B67D1E100601B55 /* PostPhotoScroll.swift in Sources */,
 				B1EE249A2B6144C5007F68B0 /* RecordViewModel.swift in Sources */,
 				B1EE24732B61431A007F68B0 /* DummyModel.swift in Sources */,
+				7B6D76AF2B67CFC900601B55 /* PostInfo.swift in Sources */,
 				B1EE249E2B6144DD007F68B0 /* DrinkInfoViewModel.swift in Sources */,
 				096E631A2B616F31009246CE /* DrinkGridCell.swift in Sources */,
 				7B904C682B6184560052384A /* CustomTextSegment.swift in Sources */,
@@ -489,6 +500,7 @@
 				B1B8FE7F2B5EA9D900921BBE /* ContentView.swift in Sources */,
 				7B6D76A72B677A8F00601B55 /* Button.swift in Sources */,
 				096E63182B616886009246CE /* DrinkListCell.swift in Sources */,
+				7B6D76AB2B67CE3D00601B55 /* PostDetailView.swift in Sources */,
 				B158F83B2B6539FC00E33C47 /* EnabledBottomSheetView.swift in Sources */,
 				B1EE24982B6144BD007F68B0 /* LikedViewModel.swift in Sources */,
 				B1EE24962B6144A5007F68B0 /* MypageViewModel.swift in Sources */,
@@ -517,6 +529,8 @@
 				B158F83F2B657A9000E33C47 /* Theme.swift in Sources */,
 				B1EE24882B61445E007F68B0 /* MypageView.swift in Sources */,
 				AC502D712B62A21700C2BD6A /* CustomNavigation.swift in Sources */,
+				7B6D76AD2B67CE6500601B55 /* Handler.swift in Sources */,
+				7B6D76B52B67D5F900601B55 /* PostTags.swift in Sources */,
 				7B904C662B6168C60052384A /* PostCell.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/FinalHrmiProjects/Resource/Handler.swift
+++ b/FinalHrmiProjects/Resource/Handler.swift
@@ -1,0 +1,66 @@
+//
+//  Handler.swift
+//  FinalHrmiProjects
+//
+//  Created by Minjae Kim on 1/29/24.
+//
+
+import SwiftUI
+
+// Tag 관련 Method 담고있는 namespace
+enum TagHandler {
+	// horizontal에 들어가있는 padding 값 20씩해서 화면 width에서 40을 빼준 width 값을 얻기 위한 메서드
+	static func getScreenWidth(padding: CGFloat) -> CGFloat {
+		let scenes = UIApplication.shared.connectedScenes
+		let windowScene = scenes.first as? UIWindowScene
+		let window = windowScene?.windows.first
+		let windowWidth = (window?.screen.bounds.width ?? 0) - (padding * 2)
+		return windowWidth
+	}
+	
+	// string에 대한 fontSize를 get하는 메서드
+	fileprivate static func getFontSize(tag: String, fontSize: CGFloat) -> CGFloat {
+		let font = UIFont.systemFont(ofSize: fontSize)
+		let attributes = [NSAttributedString.Key.font: font]
+		let size = (tag as NSString).size(withAttributes: attributes)
+		return size.width
+	}
+	
+	// tag로 가져온 문자열 배열을 화면의 width에 맞게 계산하여 2차원 배열로 매핑해주기 위한 메서드
+	static func getRows(tags: [String], spacing: CGFloat, fontSize: CGFloat, windowWidth: CGFloat, tagString: String = "") -> [[String]] {
+		var rows: [[String]] = [] // tag 값을 담아주기 위한 2차원 배열 프로퍼티
+		var currentRow: [String] = [] // 화면상의 width에 맞게 tag 배열을 잘라 2차원 배열에 담아줄 프로퍼티
+		var totalWidth: CGFloat = 0 // 화면상의 width와 비교하여 계산하기 위한 1차원 배열의 총 width를 계산해서 담아줄 저장 프로퍼티
+		
+		tags.forEach { tag in
+			let fontSize = getFontSize(tag: tagString + tag, fontSize: fontSize) + spacing // size = "# " + tag 문자열 + spacing(15)
+			totalWidth += fontSize
+			
+			// 1. 총합 width가 화면 상의 width 보다 클 경우
+			if totalWidth > windowWidth {
+				// 2. 잘라주며 담아준 1차원 배열을 2차원 배열에 append
+				rows.append(currentRow)
+				// 3. 1차원 배열의 데이터를 다 지워주면서
+				currentRow.removeAll()
+				// 4. 최근 tag값을 1차원 배열에 append
+				currentRow.append(tag)
+				// 5. 총합 width에 계산된 최근 tag에 대한 width값을 담아준다.
+				totalWidth = fontSize
+			} else {
+				// 1. 총합 width가 화면 상의 width 보다 작을 경우
+				// 2. 1차원 배열에 tag 값을 append
+				currentRow.append(tag)
+			}
+		}
+		
+		// 1. tag값이 담긴 1차원 배열에 데이터가 남아있는 경우
+		if !currentRow.isEmpty {
+			// 2. 2차원 배열에 1차원 배열을 append
+			rows.append(currentRow)
+			// 3. tag값이 담긴 1차원 배열의 데이터를 다 지워준다
+			currentRow.removeAll()
+		}
+		
+		return rows
+	}
+}

--- a/FinalHrmiProjects/View/Posts/PostDetailView.swift
+++ b/FinalHrmiProjects/View/Posts/PostDetailView.swift
@@ -43,28 +43,30 @@ struct PostDetailView: View {
 	@State private var windowWidth: CGFloat = 0
 	
 	var body: some View {
-		VStack {
-			ScrollView {
-				PostInfo(userName: "hrmi",
-						 profileImageName: "appIcon",
-						 postUploadDate: "2023.12.08",
-						 isLike: $isLike,
-						 likeCount: $likeCount)
-				
-				PostPhotoScroll(postPhotos: postPhotos)
-				
-				VStack(spacing: 20) {
-					PostDrinkRating(userName: "hrmi",
-									postDrinks: postDrinks,
-									postDrinksStarRating: postDrinksStarRating)
-					CustomDivider()
+		NavigationStack {
+			VStack {
+				ScrollView {
+					PostInfo(userName: "hrmi",
+							 profileImageName: "appIcon",
+							 postUploadDate: "2023.12.08",
+							 isLike: $isLike,
+							 likeCount: $likeCount)
 					
-					Text(postContent)
-						.font(.regular16)
+					PostPhotoScroll(postPhotos: postPhotos)
 					
-					PostTags(tags: tags, windowWidth: windowWidth)
+					VStack(spacing: 20) {
+						PostDrinkRating(userName: "hrmi",
+										postDrinks: postDrinks,
+										postDrinksStarRating: postDrinksStarRating)
+						CustomDivider()
+						
+						Text(postContent)
+							.font(.regular16)
+						
+						PostTags(tags: tags, windowWidth: windowWidth)
+					}
+					.padding(.horizontal, 20)
 				}
-				.padding(.horizontal, 20)
 			}
 		}
 		.task {

--- a/FinalHrmiProjects/View/Posts/PostDetailView.swift
+++ b/FinalHrmiProjects/View/Posts/PostDetailView.swift
@@ -1,0 +1,79 @@
+//
+//  PostDetailView.swift
+//  FinalHrmiProjects
+//
+//  Created by Minjae Kim on 1/29/24.
+//
+
+import SwiftUI
+
+enum PostUserType {
+	case writter, reader
+}
+
+struct PostDetailView: View {
+	
+	let postUserType: PostUserType
+	
+	let nickName: String
+	
+	@Binding var isLike: Bool
+	@Binding var likeCount: Int
+	
+	private let postPhotos = ["foodEx1", "foodEx2", "foodEx3", "foodEx4"]
+	
+	private let postDrinks = ["카누카 칵테일 700ml", "글렌알라키 10년 캐스크 스트래쓰 700ml", "카누카 칵테일 700ml"]
+	private let postDrinksStarRating = [4.5, 4.0, 5.0]
+	
+	private let postContent = """
+방어는 다양한 방법으로 맛있게 조리할 수 있습니다. 다음은 몇 가지 방어를 맛있게 먹는 방법들입니다:
+
+1. 구이나 튀김: 방어는 오븐이나 프라이팬에서 구워서 먹을 수 있습니다. 신선한 방어에 소금, 후추, 올리브 오일, 식초, 다양한 허브를 더해주면 풍부한 맛을 즐길 수 있습니다. 
+2. 조림: 방어를 간장, 설탕, 다진 마늘, 생강과 함께 끓여서 조림으로 만들 수 있습니다. 이 방법은 방어의 부드러운 풍미를 강조해줍니다. 
+3. 회: 신선한 방어를 얇게 썬 후 레몬 주스나 간장 소스와 함께 먹는 것도 맛있습니다. 신선한 재료로 만들어진 회는 풍부한 맛과 신선한 식감을 제공합니다. 
+4. 구운 방어 김밥: 구운 방어를 김밥 속에 넣어 간단한 반찬 또는 간식으로 먹을 수 있습니다. 신선한 야채와 함께 감칠맛을 더할 수 있습니다.
+
+양식과 한식, 다양한 조리법을 통해 방어를 다양하게 즐길 수 있으니 자신의 취향에 맞게 시도해보세요!
+"""
+	
+	private let tags = ["대방어", "새우튀김", "광어", "우럭", "이거 한 줄에 몇개 넣어야 할까?", "정렬 문제도", "뭘까", "짬뽕", "짜장", "탕수육", "팔보채", "치킨", "피자", "족발"]
+	
+	@State private var currentPage = 0
+	
+	@State private var windowWidth: CGFloat = 0
+	
+	var body: some View {
+		VStack {
+			ScrollView {
+				PostInfo(userName: "hrmi",
+						 profileImageName: "appIcon",
+						 postUploadDate: "2023.12.08",
+						 isLike: $isLike,
+						 likeCount: $likeCount)
+				
+				PostPhotoScroll(postPhotos: postPhotos)
+				
+				VStack(spacing: 20) {
+					PostDrinkRating(userName: "hrmi",
+									postDrinks: postDrinks,
+									postDrinksStarRating: postDrinksStarRating)
+					CustomDivider()
+					
+					Text(postContent)
+						.font(.regular16)
+					
+					PostTags(tags: tags, windowWidth: windowWidth)
+				}
+				.padding(.horizontal, 20)
+			}
+		}
+		.task {
+			windowWidth = TagHandler.getScreenWidth(padding: 20)
+		}
+	}
+}
+
+#Preview {
+	PostDetailView(postUserType: .writter, nickName: "hrmi", isLike: .constant(false), likeCount: .constant(45))
+}
+

--- a/FinalHrmiProjects/View/Posts/PostDrinkRating.swift
+++ b/FinalHrmiProjects/View/Posts/PostDrinkRating.swift
@@ -30,6 +30,7 @@ struct PostDrinkRating: View {
 							.lineLimit(1)
 						Spacer()
 						
+						// TODO: need StarRating code modify
 						let rating = postDrinksStarRating[index]
 						let fullStars = Int(rating)
 						let hasHalfStar = (rating - Double(fullStars)) >= 0.5

--- a/FinalHrmiProjects/View/Posts/PostDrinkRating.swift
+++ b/FinalHrmiProjects/View/Posts/PostDrinkRating.swift
@@ -1,0 +1,55 @@
+//
+//  PostDrinkRating.swift
+//  FinalHrmiProjects
+//
+//  Created by Minjae Kim on 1/29/24.
+//
+
+import SwiftUI
+
+struct PostDrinkRating: View {
+	
+	let userName: String
+	let postDrinks: [String]
+	let postDrinksStarRating: [Double]
+	
+    var body: some View {
+		VStack(spacing: 20) {
+			HStack {
+				Text("\(userName)의 술평가")
+					.font(.bold16)
+				Spacer()
+			}
+			ForEach(0..<postDrinks.count, id:\.self) { index in
+				HStack(spacing: 2) {
+					Text(postDrinks[index])
+						.font(.semibold16)
+						.lineLimit(1)
+					Spacer()
+					
+					let rating = postDrinksStarRating[index]
+					let fullStars = Int(rating)
+					let hasHalfStar = (rating - Double(fullStars)) >= 0.5
+					HStack(spacing: 5) {
+						HStack(spacing: 0) {
+							ForEach(0..<5) { index in
+								Image(systemName: index < fullStars ? "star.fill" : (hasHalfStar && index == fullStars ? "star.leadinghalf.filled" : "star"))
+									.foregroundStyle(.mainAccent03)
+							}
+						}
+						Text(String(format: "%.1F", postDrinksStarRating[index]))
+							.font(.semibold14)
+						Image(systemName: "chevron.forward")
+					}
+				}
+				.padding(.horizontal, 10)
+			}
+		}
+    }
+}
+
+#Preview {
+	PostDrinkRating(userName: "hrmi",
+					postDrinks: ["카누카 칵테일 700ml", "글렌알라키 10년 캐스크 스트래쓰 700ml", "카누카 칵테일 700ml"],
+					postDrinksStarRating: [4.5, 4.0, 5.0])
+}

--- a/FinalHrmiProjects/View/Posts/PostDrinkRating.swift
+++ b/FinalHrmiProjects/View/Posts/PostDrinkRating.swift
@@ -21,28 +21,33 @@ struct PostDrinkRating: View {
 				Spacer()
 			}
 			ForEach(0..<postDrinks.count, id:\.self) { index in
-				HStack(spacing: 2) {
-					Text(postDrinks[index])
-						.font(.semibold16)
-						.lineLimit(1)
-					Spacer()
-					
-					let rating = postDrinksStarRating[index]
-					let fullStars = Int(rating)
-					let hasHalfStar = (rating - Double(fullStars)) >= 0.5
-					HStack(spacing: 5) {
-						HStack(spacing: 0) {
-							ForEach(0..<5) { index in
-								Image(systemName: index < fullStars ? "star.fill" : (hasHalfStar && index == fullStars ? "star.leadinghalf.filled" : "star"))
-									.foregroundStyle(.mainAccent03)
+				NavigationLink {
+					// TODO: DrinkInfoView Linking code
+				} label: {
+					HStack(spacing: 2) {
+						Text(postDrinks[index])
+							.font(.semibold16)
+							.lineLimit(1)
+						Spacer()
+						
+						let rating = postDrinksStarRating[index]
+						let fullStars = Int(rating)
+						let hasHalfStar = (rating - Double(fullStars)) >= 0.5
+						HStack(spacing: 5) {
+							HStack(spacing: 0) {
+								ForEach(0..<5) { index in
+									Image(systemName: index < fullStars ? "star.fill" : (hasHalfStar && index == fullStars ? "star.leadinghalf.filled" : "star"))
+										.foregroundStyle(.mainAccent03)
+								}
 							}
+							Text(String(format: "%.1F", postDrinksStarRating[index]))
+								.font(.semibold14)
+							Image(systemName: "chevron.forward")
 						}
-						Text(String(format: "%.1F", postDrinksStarRating[index]))
-							.font(.semibold14)
-						Image(systemName: "chevron.forward")
 					}
+					.foregroundStyle(.mainBlack)
+					.padding(.horizontal, 10)
 				}
-				.padding(.horizontal, 10)
 			}
 		}
     }

--- a/FinalHrmiProjects/View/Posts/PostInfo.swift
+++ b/FinalHrmiProjects/View/Posts/PostInfo.swift
@@ -18,6 +18,7 @@ struct PostInfo: View {
 	
     var body: some View {
 		HStack {
+			// TODO: user의 profile 탭 할 경우, navigationLink로 user profile로 이동할 수 있도록 추후 구현 예정
 			// 사용자의 프로필 사진
 			Image(profileImageName)
 				.resizable()

--- a/FinalHrmiProjects/View/Posts/PostInfo.swift
+++ b/FinalHrmiProjects/View/Posts/PostInfo.swift
@@ -1,0 +1,74 @@
+//
+//  PostInfo.swift
+//  FinalHrmiProjects
+//
+//  Created by Minjae Kim on 1/29/24.
+//
+
+import SwiftUI
+
+struct PostInfo: View {
+	
+	let userName: String
+	let profileImageName: String
+	let postUploadDate: String
+	
+	@Binding var isLike: Bool
+	@Binding var likeCount: Int
+	
+    var body: some View {
+		HStack {
+			// 사용자의 프로필 사진
+			Image(profileImageName)
+				.resizable()
+				.frame(width: 30, height: 30)
+				.clipShape(.circle)
+			
+			VStack(alignment: .leading) {
+				// 사용자의 닉네임
+				Text(userName)
+					.lineLimit(1)
+					.font(.regular18)
+					.foregroundStyle(.mainBlack)
+				// 게시글 올린 날짜
+				Text(postUploadDate)
+					.font(.regular14)
+					.foregroundStyle(.gray01)
+			}
+			
+			Spacer()
+			
+			// 좋아요 버튼
+			HStack(spacing: 3) {
+				// 좋아요를 등록 -> 빨간색이 채워진 하트
+				// 좋아요를 해제 -> 테두리가 회색인 하트
+				Image(systemName: isLike ? "heart.fill" : "heart")
+					.foregroundStyle(isLike ? .mainAccent01 : .gray01)
+				Text("\(likeCount)")
+					.foregroundStyle(.gray01)
+			}
+			.font(.regular16)
+			.padding(.trailing, 10)
+			.onTapGesture {
+				likeButtonAction()
+			}
+		}
+		.padding(.horizontal, 20)
+    }
+	
+	// 좋아요 버튼 액션 메서드
+	private func likeButtonAction() {
+		// 좋아요 등록 -> 좋아요 수에 + 1
+		// 좋아요 해제 -> 좋아요 수에 - 1
+		if isLike {
+			likeCount -= 1
+		} else {
+			likeCount += 1
+		}
+		isLike.toggle()
+	}
+}
+
+#Preview {
+	PostInfo(userName: "hrmi", profileImageName: "appIcon", postUploadDate: "2023.12.08", isLike: .constant(false), likeCount: .constant(45))
+}

--- a/FinalHrmiProjects/View/Posts/PostPhotoScroll.swift
+++ b/FinalHrmiProjects/View/Posts/PostPhotoScroll.swift
@@ -1,0 +1,31 @@
+//
+//  PostPhotoScroll.swift
+//  FinalHrmiProjects
+//
+//  Created by Minjae Kim on 1/29/24.
+//
+
+import SwiftUI
+
+struct PostPhotoScroll: View {
+	
+	let postPhotos: [String]
+	
+    var body: some View {
+		TabView {
+			ForEach(0..<postPhotos.count, id: \.self) { index in
+				Image(postPhotos[index])
+					.resizable()
+					.aspectRatio(contentMode: .fill)
+					.clipped()
+			}
+		}
+		.frame(height: 350)
+		.padding(.bottom, 10)
+		.tabViewStyle(.page)
+    }
+}
+
+#Preview {
+	PostPhotoScroll(postPhotos: ["foodEx1", "foodEx2", "foodEx3", "foodEx4"])
+}

--- a/FinalHrmiProjects/View/Posts/PostPhotoScroll.swift
+++ b/FinalHrmiProjects/View/Posts/PostPhotoScroll.swift
@@ -43,7 +43,7 @@ struct PostPhotoScroll: View {
 				Button {
 					isFullSizePhotoPresented = false
 				} label: {
-					Image(systemName: "xmark.circle")
+					Image(systemName: "xmark")
 						.foregroundStyle(.gray01)
 						.font(.bold20)
 				}

--- a/FinalHrmiProjects/View/Posts/PostPhotoScroll.swift
+++ b/FinalHrmiProjects/View/Posts/PostPhotoScroll.swift
@@ -11,18 +11,46 @@ struct PostPhotoScroll: View {
 	
 	let postPhotos: [String]
 	
+	@State private var selectedIndex = 0
+	@State private var isFullSizePhotoPresented = false
+	
     var body: some View {
-		TabView {
+		TabView(selection: $selectedIndex) {
 			ForEach(0..<postPhotos.count, id: \.self) { index in
 				Image(postPhotos[index])
 					.resizable()
 					.aspectRatio(contentMode: .fill)
 					.clipped()
+					.onTapGesture {
+						isFullSizePhotoPresented = true
+					}
 			}
 		}
 		.frame(height: 350)
 		.padding(.bottom, 10)
 		.tabViewStyle(.page)
+		.fullScreenCover(isPresented: $isFullSizePhotoPresented) {
+			ZStack(alignment: .topLeading) {
+				Color.black
+				
+				TabView(selection: $selectedIndex) {
+					ForEach(0..<postPhotos.count, id: \.self) { index in
+						Image(postPhotos[index])
+					}
+				}
+				.tabViewStyle(.page)
+				
+				Button {
+					isFullSizePhotoPresented = false
+				} label: {
+					Image(systemName: "xmark.circle")
+						.foregroundStyle(.gray01)
+						.font(.bold20)
+				}
+				.padding(30)
+			}
+			.ignoresSafeArea()
+		}
     }
 }
 

--- a/FinalHrmiProjects/View/Posts/PostTags.swift
+++ b/FinalHrmiProjects/View/Posts/PostTags.swift
@@ -19,11 +19,15 @@ struct PostTags: View {
 									   fontSize: 14,
 									   windowWidth: windowWidth,
 									   tagString: "# "), id: \.self) { row in
-				HStack(spacing: 15) {
-					ForEach(row, id: \.self) { tag in
-						Text("# \(tag)")
-							.font(.semibold14)
-							.foregroundStyle(.mainAccent04)
+				NavigationLink {
+					// TODO: PostView Linking code
+				} label: {
+					HStack(spacing: 15) {
+						ForEach(row, id: \.self) { tag in
+							Text("# \(tag)")
+								.font(.semibold14)
+								.foregroundStyle(.mainAccent04)
+						}
 					}
 				}
 			}

--- a/FinalHrmiProjects/View/Posts/PostTags.swift
+++ b/FinalHrmiProjects/View/Posts/PostTags.swift
@@ -1,0 +1,37 @@
+//
+//  PostTags.swift
+//  FinalHrmiProjects
+//
+//  Created by Minjae Kim on 1/29/24.
+//
+
+import SwiftUI
+
+struct PostTags: View {
+	
+	let tags: [String]
+	let windowWidth: CGFloat
+	
+    var body: some View {
+		VStack(alignment: .leading, spacing: 10) {
+			ForEach(TagHandler.getRows(tags: tags,
+									   spacing: 15,
+									   fontSize: 14,
+									   windowWidth: windowWidth,
+									   tagString: "# "), id: \.self) { row in
+				HStack(spacing: 15) {
+					ForEach(row, id: \.self) { tag in
+						Text("# \(tag)")
+							.font(.semibold14)
+							.foregroundStyle(.mainAccent04)
+					}
+				}
+			}
+		}
+		.frame(width: windowWidth, alignment: .leading)
+    }
+}
+
+//#Preview {
+//    PostTags()
+//}


### PR DESCRIPTION
## 개요 (이슈 번호 및 요약)
- #37 
## 변경 사항 (작업 내용)
### Image Horizontal Scroll
 - TabView의 paging 스타일
 - Instagram 피드 스타일
 - 사진 탭 할 경우, fullSizeCover로 사진 원본 비율로 보여주기

### Dynamic Tag Lineup
- VStack에서 동적으로 HStack의 width값이 아이폰 화면상의 width값을 벗어나면
- 줄바꿈 하듯이 HStack을 계속 추가하는 방식


## 스크린샷
![image](https://github.com/APP-iOS3rd/PJ4T7_HrMi/assets/80156515/1c6b9b1d-7298-4dad-bb7b-6b1eea9acc54)
![image](https://github.com/APP-iOS3rd/PJ4T7_HrMi/assets/80156515/627fff8d-0fd0-465d-a819-834fe8431c8e)
![image](https://github.com/APP-iOS3rd/PJ4T7_HrMi/assets/80156515/8ecb8836-61e6-454a-b02d-e91638aa24b1)
![image](https://github.com/APP-iOS3rd/PJ4T7_HrMi/assets/80156515/b8b39fd2-f11b-4fa1-b301-2a44121e7d94)


## 특이사항 (트러블 슈팅 과정 및 참고 자료 등)
- userData 보여주는 PostInfo
   - 추후에 사용자 프로필 이미지를 탭할 경우 사용자의 프로필을 보여주는 뷰로 이동할 수 있는 기능 구현

- Image Horizontal Scroll
   - 최대한 피그마대로 하려했으나 현재로선 기술적인 어려움이 있어 
   - TabView의 paging 스타일로 변경

- user의 술에 대한 평점을 보여주는 PostDrinkRating
   - 컴포넌트로 구현된 view로 코드 재작성 예정
   - navigationLink를 통해 DrinkInfoView 연결 코드 추후 작성 예정

- 게시글의 tag들을 보여주는 PostTags
   - tag를 탭 할 경우, navigationLink를 통해 PostView에 tag를 검색할 수 있게 추후 코드 작성 예정