### PR TITLE
[Edit] CustomScrollView 에서 ScrollView + ViewThatFits 로 수정 #89

### DIFF
--- a/FinalHrmiProjects/Resource/Components/CustomScrollView.swift
+++ b/FinalHrmiProjects/Resource/Components/CustomScrollView.swift
@@ -9,8 +9,7 @@ import SwiftUI
 
 // MARK: content 가 가 화면 크기를 넘어가야만 scrollView 작동하도록하는 커스텀 스크롤 뷰
 struct CustomScrollView<Content: View>: View {
-    @Binding var scrollAxis: Axis.Set
-    @Binding var vHeight: Double
+    @State private var scrollAxis: Axis.Set = .vertical
     let content: () -> Content
     
     var body: some View {
@@ -20,11 +19,10 @@ struct CustomScrollView<Content: View>: View {
                 .background(
                     GeometryReader { contentGeo in
                         Color.clear
-                            .onAppear {
-                                vHeight = Double(contentGeo.size.height)
-                            }
-                            .onChange(of: scrollGeo.size.height) {
-                                scrollAxis = contentGeo.size.height > $0 ? .vertical : []
+                            .task {
+                                if contentGeo.size.height <= scrollGeo.size.height {
+                                    scrollAxis = []
+                                }
                             }
                     }
                 )

--- a/FinalHrmiProjects/View/DrinkInfo/DrinkInfoGrid.swift
+++ b/FinalHrmiProjects/View/DrinkInfo/DrinkInfoGrid.swift
@@ -8,29 +8,50 @@
 import SwiftUI
 
 struct DrinkInfoGrid: View {
+    
+    var body: some View {
+        // MARK: iOS 16.4 이상
+        if #available(iOS 16.4, *) {
+            ScrollView() {
+                DrinkGridContent()
+            }
+            .scrollBounceBehavior(.basedOnSize, axes: .vertical)
+            .scrollIndicators(.hidden)
+            .scrollDismissesKeyboard(.immediately)
+        // MARK: iOS 16.4 미만
+        } else {
+            ViewThatFits(in: .vertical) {
+                DrinkGridContent()
+                    .frame(maxHeight: .infinity, alignment: .top)
+                ScrollView {
+                    DrinkGridContent()
+                }
+                .scrollIndicators(.hidden)
+                .scrollDismissesKeyboard(.immediately)
+            }
+        }
+    }
+}
+
+struct DrinkGridContent: View {
     // 술 그리드 셀 2개 column
     private let columns: [GridItem] = [GridItem(.flexible()), GridItem(.flexible())]
     
-	@State private var scrollAxis: Axis.Set = .vertical
-	@State private var vHeight = 0.0
-	
     var body: some View {
-        CustomScrollView(scrollAxis: $scrollAxis, vHeight: $vHeight) {
-            // 그리드
-            LazyVGrid(columns: columns, spacing: 10) {
-                // TODO: 현재 더미데이터 10개를 보여주지만, 데이터 들어온 리스트로 ForEach 돌릴 예정
-                ForEach(0..<10, id: \.self) { _ in
-                    // TODO: 추후에 네비게이션으로 해당 술의 Detail 로 이동 연결
-                    NavigationLink {
-						DrinkDetailView()
-					} label: {
-						DrinkGridCell()
-					}
+        // 그리드
+        LazyVGrid(columns: columns, spacing: 10) {
+            // TODO: 현재 더미데이터 10개를 보여주지만, 데이터 들어온 리스트로 ForEach 돌릴 예정
+            ForEach(0..<10, id: \.self) { _ in
+                // TODO: 추후에 네비게이션으로 해당 술의 Detail 로 이동 연결
+                NavigationLink {
+                    DrinkDetailView()
+                } label: {
+                    DrinkGridCell()
                 }
             }
-            .padding(.horizontal, 20)
-            .padding(.vertical, 10)
         }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 10)
     }
 }
 

--- a/FinalHrmiProjects/View/DrinkInfo/DrinkInfoList.swift
+++ b/FinalHrmiProjects/View/DrinkInfo/DrinkInfoList.swift
@@ -8,21 +8,43 @@
 import SwiftUI
 
 struct DrinkInfoList: View {
-	@State private var scrollAxis: Axis.Set = .vertical
-	@State private var vHeight = 0.0
-	
+    
     var body: some View {
-        CustomScrollView(scrollAxis: $scrollAxis, vHeight: $vHeight) {
-            // 리스트
-            LazyVStack(spacing: 0) {
-                // TODO: 현재 더미데이터 10개를 보여주지만, 데이터 들어온 리스트로 ForEach 돌릴 예정
-                ForEach(0..<10, id: \.self) { _ in
-                    // TODO: 추후에 네비게이션으로 해당 술의 Detail 로 이동 연결
-                    NavigationLink {
-						DrinkDetailView()
-					} label: {
-						DrinkListCell()
-					}
+        // MARK: iOS 16.4 이상
+        if #available(iOS 16.4, *) {
+            ScrollView() {
+                DrinkListContent()
+            }
+            .scrollBounceBehavior(.basedOnSize, axes: .vertical)
+            .scrollIndicators(.hidden)
+            .scrollDismissesKeyboard(.immediately)
+        // MARK: iOS 16.4 미만
+        } else {
+            ViewThatFits(in: .vertical) {
+                DrinkListContent()
+                    .frame(maxHeight: .infinity, alignment: .top)
+                ScrollView {
+                    DrinkListContent()
+                }
+                .scrollIndicators(.hidden)
+                .scrollDismissesKeyboard(.immediately)
+            }
+        }
+    }
+}
+
+struct DrinkListContent: View {
+    
+    var body: some View {
+        // 리스트
+        LazyVStack {
+            // TODO: 현재 더미데이터 10개를 보여주지만, 데이터 들어온 리스트로 ForEach 돌릴 예정
+            ForEach(0..<10, id: \.self) { _ in
+                // TODO: 추후에 네비게이션으로 해당 술의 Detail 로 이동 연결
+                NavigationLink {
+                    DrinkDetailView()
+                } label: {
+                    DrinkListCell()
                 }
             }
         }

--- a/FinalHrmiProjects/View/Liked/LikedDrinkList.swift
+++ b/FinalHrmiProjects/View/Liked/LikedDrinkList.swift
@@ -8,20 +8,39 @@
 import SwiftUI
 
 struct LikedDrinkList: View {
-    @State private var scrollAxis: Axis.Set = .vertical
-    @State private var vHeight = 0.0
 
     var body: some View {
-        CustomScrollView(scrollAxis: $scrollAxis,
-                         vHeight: $vHeight) {
-            LazyVStack {
-                ForEach(0..<3, id: \.self) { _ in
-                    // TODO: 추후에 네비게이션으로 해당 술의 Detail 로 이동 연결
-                    NavigationLink {
-						DrinkDetailView()
-					} label: {
-						DrinkListCell()
-					}
+        // MARK: iOS 16.4 이상
+        if #available(iOS 16.4, *) {
+            ScrollView() {
+                LikedDrinkListContent()
+            }
+            .scrollBounceBehavior(.basedOnSize, axes: .vertical)
+            .scrollIndicators(.hidden)
+        // MARK: iOS 16.4 미만
+        } else {
+            ViewThatFits(in: .vertical) {
+                LikedDrinkListContent()
+                    .frame(maxHeight: .infinity, alignment: .top)
+                ScrollView {
+                    LikedDrinkListContent()
+                }
+                .scrollIndicators(.hidden)
+            }
+        }
+    }
+}
+
+// MARK: - 스크롤 뷰 or 뷰 로 보여질 술찜 리스트
+struct LikedDrinkListContent: View {
+    var body: some View {
+        LazyVStack {
+            ForEach(0..<3, id: \.self) { _ in
+                // TODO: 추후에 네비게이션으로 해당 술의 Detail 로 이동 연결
+                NavigationLink {
+                    DrinkDetailView()
+                } label: {
+                    DrinkListCell()
                 }
             }
         }

--- a/FinalHrmiProjects/View/Liked/LikedPostGrid.swift
+++ b/FinalHrmiProjects/View/Liked/LikedPostGrid.swift
@@ -8,33 +8,54 @@
 import SwiftUI
 
 struct LikedPostGrid: View {
-    @State private var scrollAxis: Axis.Set = .vertical
-    @State private var vHeight = 0.0
     // 현재 유저가 해당 술 상을 좋아요 눌렀는지 bool
     @State private var isLikePost = true
     // 게시물
     @State private var postLikeCount = 45
-    // UITest - 술상 그리드 셀 2개 column
-    private let columns: [GridItem] = [
-        GridItem(.flexible()),
-        GridItem(.flexible())
-    ]
 
     var body: some View {
-        CustomScrollView(scrollAxis: $scrollAxis,
-                         vHeight: $vHeight) {
-            LazyVGrid(columns: columns, spacing: 10) {
-                ForEach(0..<8, id: \.self) { _ in
-                    // TODO: 추후에 네비게이션으로 해당 술상의 Detail 로 이동 연결
-					NavigationLink {
-						PostDetailView(postUserType: .reader, nickName: "Hrmi", isLike: $isLikePost, likeCount: $postLikeCount)
-					} label: {
-						PostCell(isLike: $isLikePost, likeCount: $postLikeCount)
-					}
+        // MARK: iOS 16.4 이상
+        if #available(iOS 16.4, *) {
+            ScrollView() {
+                LikedDrinkGridContent(isLikePost: $isLikePost, postLikeCount: $postLikeCount)
+            }
+            .scrollBounceBehavior(.basedOnSize, axes: .vertical)
+            .scrollIndicators(.hidden)
+        // MARK: iOS 16.4 미만
+        } else {
+            ViewThatFits(in: .vertical) {
+                LikedDrinkGridContent(isLikePost: $isLikePost, postLikeCount: $postLikeCount)
+                    .frame(maxHeight: .infinity, alignment: .top)
+                ScrollView {
+                    LikedDrinkGridContent(isLikePost: $isLikePost, postLikeCount: $postLikeCount)
+                }
+                .scrollIndicators(.hidden)
+            }
+        }
+    }
+}
+
+// MARK: - 스크롤 뷰 or 뷰 로 보여질 술상 그리드
+struct LikedDrinkGridContent: View {
+    // 현재 유저가 해당 술 상을 좋아요 눌렀는지 bool
+    @Binding var isLikePost: Bool
+    // 게시물
+    @Binding var postLikeCount: Int
+    // UITest - 술상 그리드 셀 2개 column
+    private let columns: [GridItem] = [GridItem(.flexible()), GridItem(.flexible())]
+    
+    var body: some View {
+        LazyVGrid(columns: columns, spacing: 10) {
+            ForEach(0..<8, id: \.self) { _ in
+                // TODO: 추후에 네비게이션으로 해당 술상의 Detail 로 이동 연결
+                NavigationLink {
+                    PostDetailView(postUserType: .reader, nickName: "Hrmi", isLike: $isLikePost, likeCount: $postLikeCount)
+                } label: {
+                    PostCell(isLike: $isLikePost, likeCount: $postLikeCount)
                 }
             }
-            .padding(.horizontal, 20)
         }
+        .padding(.horizontal, 20)
     }
 }
 

--- a/FinalHrmiProjects/View/Mypage/MypageDetail/AlarmStoreView.swift
+++ b/FinalHrmiProjects/View/Mypage/MypageDetail/AlarmStoreView.swift
@@ -42,22 +42,27 @@ struct AlarmStoreView: View {
     
     var body: some View {
         VStack(spacing: 0) {
-            // TODO: CustomScrollView 로 수정 예정
-            ScrollView {
-                ForEach(0..<Alarm.alarmList.count, id: \.self) { index in
-                    NavigationLink {
-						PostDetailView(postUserType: .writter, nickName: "Hrmi", isLike: .constant(false), likeCount: .constant(45))
-                    } label: {
-                        AlarmStoreListCell(alarm: Alarm.alarmList[index])
-                    }
-
-                    if index != Alarm.alarmList.count - 1 {
-                        CustomDivider()
-                    }
+            // 알람 리스트
+            // MARK: iOS 16.4 이상
+            if #available(iOS 16.4, *) {
+                ScrollView() {
+                    AlarmListContent()
                 }
+                .scrollBounceBehavior(.basedOnSize, axes: .vertical)
+                .scrollIndicators(.hidden)
+                .padding(.top, 10)
+            // MARK: iOS 16.4 미만
+            } else {
+                ViewThatFits(in: .vertical) {
+                    AlarmListContent()
+                        .frame(maxHeight: .infinity, alignment: .top)
+                    ScrollView {
+                        AlarmListContent()
+                    }
+                    .scrollIndicators(.hidden)
+                }
+                .padding(.top, 10)
             }
-            .scrollIndicators(.hidden)
-            .padding(.top, 10)
         }
         .navigationBarBackButtonHidden()
         .toolbar {
@@ -74,6 +79,25 @@ struct AlarmStoreView: View {
                 Text("알림")
                     .font(.regular16)
                     .foregroundStyle(.mainBlack)
+            }
+        }
+    }
+}
+
+// MARK: - 스크롤 뷰 or 뷰 로 보여질 알람 리스트
+struct AlarmListContent: View {
+    var body: some View {
+        LazyVStack {
+            ForEach(0..<Alarm.alarmList.count, id: \.self) { index in
+                NavigationLink {
+                    PostDetailView(postUserType: .writter, nickName: "Hrmi", isLike: .constant(false), likeCount: .constant(45))
+                } label: {
+                    AlarmStoreListCell(alarm: Alarm.alarmList[index])
+                }
+                
+                if index != Alarm.alarmList.count - 1 {
+                    CustomDivider()
+                }
             }
         }
     }

--- a/FinalHrmiProjects/View/Mypage/MypageView.swift
+++ b/FinalHrmiProjects/View/Mypage/MypageView.swift
@@ -35,23 +35,24 @@ struct MypageView: View {
                 .padding(.horizontal, 20)
                 .padding(.top, 20)
                 
-                // MARK: - [LazyVGrid - 사용자가 작성한 글]
-                ScrollView {
-                    LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 16) {
-                        ForEach(0..<4) { _ in
-                            NavigationLink {
-                                // TODO: PostCell에 해당하는 DetailView로 이동하기
-                                PostDetailView(postUserType: .writter, nickName: "hrmi", isLike: .constant(false), likeCount: .constant(45))
-                            } label: {
-                                // TODO: 네비게이션 루트 설정
-                                // 글 누르고 back눌렀을 때 마이페이지로 다시 돌아올지 PostsView에서 있을지 루트 잘 설정해야할 듯
-                                PostCell(isLike: $isLike, likeCount: $likeCount)
-                            }
-                            // Blinking 애니메이션 삭제
-                            .buttonStyle(EmptyActionStyle())
-                        }
+                // 사용자가 작성한 글
+                // MARK: iOS 16.4 이상
+                if #available(iOS 16.4, *) {
+                    ScrollView() {
+                        PostGridContent(isLike: $isLike, likeCount: $likeCount, postUserType: .writter)
                     }
-                    .padding(.horizontal, 20)
+                    .scrollBounceBehavior(.basedOnSize, axes: .vertical)
+                    .scrollIndicators(.hidden)
+                    // MARK: iOS 16.4 미만
+                } else {
+                    ViewThatFits(in: .vertical) {
+                        PostGridContent(isLike: $isLike, likeCount: $likeCount, postUserType: .writter)
+                            .frame(maxHeight: .infinity, alignment: .top)
+                        ScrollView {
+                            PostGridContent(isLike: $isLike, likeCount: $likeCount, postUserType: .writter)
+                        }
+                        .scrollIndicators(.hidden)
+                    }
                 }
             }
             // MARK: - [마이페이지 -- '알림' | '설정']
@@ -77,7 +78,6 @@ struct MypageView: View {
                         Image(systemName: "gearshape")
                     }
                 }
-               
             }
             .foregroundStyle(.mainBlack)
         }

--- a/FinalHrmiProjects/View/Posts/PostGrid.swift
+++ b/FinalHrmiProjects/View/Posts/PostGrid.swift
@@ -18,26 +18,64 @@ struct PostGrid: View {
 	@State private var vHeight = 0.0
 	
     var body: some View {
-		// TODO: navigationLink 및 navigationDestination을 통한 RecordDetailView 전환 구현
-		CustomScrollView(scrollAxis: $scrollAxis, vHeight: $vHeight) {
-			LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 10) {
-				ForEach(0..<12, id: \.self) { _ in
-					NavigationLink {
-						PostDetailView(postUserType: postUserType,
-									   nickName: "hrmi",
-									   isLike: $isLike,
-									   likeCount: $likeCount)
-					} label: {
-						PostCell(isLike: $isLike, likeCount: $likeCount)
-					}
-					.buttonStyle(EmptyActionStyle())
-				}
-			}
-		}
-		.padding(.horizontal, 20)
-		.refreshable {
-			// TODO: write post data refresh code
-		}
+        // MARK: iOS 16.4 이상
+        if #available(iOS 16.4, *) {
+            ScrollView() {
+                PostGridContent(isLike: $isLike,
+                                      likeCount: $likeCount,
+                                      postUserType: postUserType)
+            }
+            .scrollBounceBehavior(.basedOnSize, axes: .vertical)
+            .scrollIndicators(.hidden)
+            .scrollDismissesKeyboard(.immediately)
+            .padding(.horizontal, 20)
+            .refreshable {
+                // TODO: write post data refresh code
+            }
+        // MARK: iOS 16.4 미만
+        } else {
+            ViewThatFits(in: .vertical) {
+                PostGridContent(isLike: $isLike,
+                                      likeCount: $likeCount,
+                                      postUserType: postUserType)
+                    .frame(maxHeight: .infinity, alignment: .top)
+                ScrollView {
+                    PostGridContent(isLike: $isLike,
+                                          likeCount: $likeCount,
+                                          postUserType: postUserType)
+                }
+                .scrollIndicators(.hidden)
+                .scrollDismissesKeyboard(.immediately)
+                .refreshable {
+                    // TODO: write post data refresh code
+                }
+            }
+            .padding(.horizontal, 20)
+        }
+    }
+}
+
+// MARK: - 스크롤 뷰 or 뷰 로 보여질 post grid
+struct PostGridContent: View {
+    @Binding var isLike: Bool
+    @Binding var likeCount: Int
+    
+    let postUserType: PostUserType
+
+    var body: some View {
+        LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 10) {
+            ForEach(0..<12, id: \.self) { _ in
+                NavigationLink {
+                    PostDetailView(postUserType: postUserType,
+                                   nickName: "hrmi",
+                                   isLike: $isLike,
+                                   likeCount: $likeCount)
+                } label: {
+                    PostCell(isLike: $isLike, likeCount: $likeCount)
+                }
+                .buttonStyle(EmptyActionStyle())
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## 개요 (이슈 번호 및 요약)
- close #89 

## 변경 사항 (작업 내용)
- 기존에 사용하던 CustomScrollView 이 제대로 작동하지 않는 문제.
-> 해결 위해서 CustomScrollView 코드 수정하는 쪽으로 해봤지만, 동시성 문제가 아니었음.
-> tabview 와 navigation 을 수정해놓은 테스트 파일에서 진행해봤기에... GeometryReader 문제로 예상..

- iOS 16.4 부터 ScrollView 에 지원되는 메서드가 존재.
-> `.scrollBounceBehavior(.basedOnSize, axes: .vertical)` 설정 시, 화면 크기에 맞춰서 스크롤이 되거나 안되게 설정 가능
-> **하지만** 이번 프로젝트는 16.0 부터 지원하는 프로젝트..

- 최소 지원 버전 16.0 을 맞추기 위해, https://github.com/siteline/swiftui-introspect 라이브러리를 사용해보려 했으나 spm 에러로 인해 라이브러리 사용 하지 않기로 결정..

- `ViewThatFits() {}` 를 찾게 됨..
-> 무엇.. 이냐 하냐면.. https://medium.com/the-swift-cooperative/mastering-viewthatfits-3294d74cb17b 읽어보시길..!
-> 기존에 보여줄 content 를 아래 코드처럼 사용..
-> 뷰에 맞추는 구조체이기 때문에.. content 에게 프레임을 크게 주어서 사용했음. ( 프레임이 없으면 뷰가 가운데로 맞춰지는 에러가 남 )
```swift
ViewThatFits(in: .vertical) {
    content()
        .frame(maxHeight: .infinity, alignment: .top)
    ScrollView {
        content()
    }
    .scrollIndicators(.hidden)
}
```

- 최종 코드 예시
-> 16.4 이상과 16.4 미만에 분기를 두어 코드 작성
-> 아래 코드만 써도 문제 없지만, 추후 유지보수나 안정성을 생각해서 두가지 코드 분기를 두어 사용.
```swift
// MARK: iOS 16.4 이상
if #available(iOS 16.4, *) {
    ScrollView() {
        content()
    }
    .scrollBounceBehavior(.basedOnSize, axes: .vertical)
    .scrollIndicators(.hidden)
// MARK: iOS 16.4 미만
} else {
    ViewThatFits(in: .vertical) {
        content()
            .frame(maxHeight: .infinity, alignment: .top)
        ScrollView {
            content()
        }
        .scrollIndicators(.hidden)
    }
}
```
