### PR TITLE
[Edit & Feat] 검색 기능 버그 수정, 태그 탭 후 태그 관련 포스트들 필터링 후 보여주기 완. #119

### DIFF
--- a/JUDA.xcodeproj/project.pbxproj
+++ b/JUDA.xcodeproj/project.pbxproj
@@ -22,7 +22,6 @@
 		0974A1522B8B84B600476199 /* ShimmerDrinkGridCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0974A1512B8B84B600476199 /* ShimmerDrinkGridCell.swift */; };
 		0974A1542B8B84E900476199 /* ShimmerDrinkListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0974A1532B8B84E900476199 /* ShimmerDrinkListCell.swift */; };
 		0974A15B2B8BD71B00476199 /* ShimmerPostListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0974A15A2B8BD71B00476199 /* ShimmerPostListCell.swift */; };
-		0974A15D2B8C60DE00476199 /* DrinkLoading.json in Resources */ = {isa = PBXBuildFile; fileRef = 0974A15C2B8C60DE00476199 /* DrinkLoading.json */; };
 		0999125C2B84654400E72C73 /* FirebaseCrashlytics in Frameworks */ = {isa = PBXBuildFile; productRef = 0999125B2B84654400E72C73 /* FirebaseCrashlytics */; };
 		099912652B85799800E72C73 /* CircularLoaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 099912642B85799800E72C73 /* CircularLoaderView.swift */; };
 		099D9AAE2B88749E002261F7 /* Debouncer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 099D9AAD2B88749E002261F7 /* Debouncer.swift */; };
@@ -101,6 +100,7 @@
 		7BBDFF732B6B912C0036FB8B /* DrinkInfoSegment.swift in Sources */ = {isa = PBXBuildFile; fileRef = B16EB85B2B63859800E920A3 /* DrinkInfoSegment.swift */; };
 		7BE14B952B84733900C1F6C3 /* Drink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BE14B942B84733900C1F6C3 /* Drink.swift */; };
 		7BE14B972B84767000C1F6C3 /* DrinkUploadViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BE14B962B84767000C1F6C3 /* DrinkUploadViewModel.swift */; };
+		7BFFDDA22B8CF98A001BCC0F /* DrinkLoading.json in Resources */ = {isa = PBXBuildFile; fileRef = 7BFFDDA12B8CF98A001BCC0F /* DrinkLoading.json */; };
 		AC110B572B69658C005390BB /* ChangeUserNameView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC110B562B69658C005390BB /* ChangeUserNameView.swift */; };
 		AC1BE8E62B8B99EC0015381D /* PostTopView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC1BE8E52B8B99EC0015381D /* PostTopView.swift */; };
 		AC2A053C2B88EC32003F23F7 /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = AC2A053B2B88EC32003F23F7 /* Kingfisher */; };
@@ -109,7 +109,6 @@
 		AC588E862B8CC8F10063AAB0 /* AiWellMatchViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC588E852B8CC8F10063AAB0 /* AiWellMatchViewModel.swift */; };
 		AC6D128A2B6A8ED100169B23 /* WeatherAndFood.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC6D12892B6A8ED100169B23 /* WeatherAndFood.swift */; };
 		AC797BDA2B8B8BEB0018D227 /* DrinkTopView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC797BD92B8B8BEB0018D227 /* DrinkTopView.swift */; };
-
 		AC98D1CD2B735765006F6EC9 /* Lottie in Frameworks */ = {isa = PBXBuildFile; productRef = AC98D1CC2B735765006F6EC9 /* Lottie */; };
 		AC98D1CF2B7357DA006F6EC9 /* Lottie.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC98D1CE2B7357DA006F6EC9 /* Lottie.swift */; };
 		AC98D1D22B73586F006F6EC9 /* OpenAI in Frameworks */ = {isa = PBXBuildFile; productRef = AC98D1D12B73586F006F6EC9 /* OpenAI */; };
@@ -182,7 +181,6 @@
 		0974A1512B8B84B600476199 /* ShimmerDrinkGridCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShimmerDrinkGridCell.swift; sourceTree = "<group>"; };
 		0974A1532B8B84E900476199 /* ShimmerDrinkListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShimmerDrinkListCell.swift; sourceTree = "<group>"; };
 		0974A15A2B8BD71B00476199 /* ShimmerPostListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShimmerPostListCell.swift; sourceTree = "<group>"; };
-		0974A15C2B8C60DE00476199 /* DrinkLoading.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = DrinkLoading.json; path = "../../../../흐르미/Lottie/DrinkLoading.json"; sourceTree = "<group>"; };
 		099912642B85799800E72C73 /* CircularLoaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CircularLoaderView.swift; sourceTree = "<group>"; };
 		099D9AAD2B88749E002261F7 /* Debouncer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Debouncer.swift; sourceTree = "<group>"; };
 		099F16182B750E7E00D8BEDA /* UINavigationController +.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UINavigationController +.swift"; sourceTree = "<group>"; };
@@ -255,6 +253,7 @@
 		7B9265702B6941D000840095 /* PostReportToolbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostReportToolbar.swift; sourceTree = "<group>"; };
 		7BE14B942B84733900C1F6C3 /* Drink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Drink.swift; sourceTree = "<group>"; };
 		7BE14B962B84767000C1F6C3 /* DrinkUploadViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrinkUploadViewModel.swift; sourceTree = "<group>"; };
+		7BFFDDA12B8CF98A001BCC0F /* DrinkLoading.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = DrinkLoading.json; path = ../../../../../../../../Downloads/JUDA/Lottie/DrinkLoading.json; sourceTree = "<group>"; };
 		AC110B562B69658C005390BB /* ChangeUserNameView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeUserNameView.swift; sourceTree = "<group>"; };
 		AC1BE8E52B8B99EC0015381D /* PostTopView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostTopView.swift; sourceTree = "<group>"; };
 		AC5778E42B6FC20C00F7B04B /* NavigationProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationProfileView.swift; sourceTree = "<group>"; };
@@ -388,8 +387,8 @@
 				09BCC14C2B7C7E2900FF4D1B /* Rain.json */,
 				09BCC14D2B7C7E2900FF4D1B /* Snow.json */,
 				09BCC14B2B7C7E2900FF4D1B /* Sun.json */,
+				7BFFDDA12B8CF98A001BCC0F /* DrinkLoading.json */,
 				09BCC14A2B7C7E2900FF4D1B /* Thunder.json */,
-				0974A15C2B8C60DE00476199 /* DrinkLoading.json */,
 			);
 			path = Lottie;
 			sourceTree = "<group>";
@@ -499,7 +498,6 @@
 			isa = PBXGroup;
 			children = (
 				B1B8FE7B2B5EA9D900921BBE /* JUDA */,
-				AC588E822B8C55F70063AAB0 /* Frameworks */,
 				0974A14A2B8B787E00476199 /* JUDA.app */,
 			);
 			sourceTree = "<group>";
@@ -844,6 +842,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				09BCC1512B7C7E2900FF4D1B /* Sun.json in Resources */,
+				7BFFDDA22B8CF98A001BCC0F /* DrinkLoading.json in Resources */,
 				7B0A8BC72B8C614000740E61 /* DrinkLoading.json in Resources */,
 				09BCC1502B7C7E2900FF4D1B /* Thunder.json in Resources */,
 				B1B8FE8D2B5EAAAB00921BBE /* Colors.xcassets in Resources */,

--- a/JUDA/View/ContentView/ContentView.swift
+++ b/JUDA/View/ContentView/ContentView.swift
@@ -101,6 +101,7 @@ struct ContentView: View {
                 MypageView(selectedTabIndex: $selectedTabIndex)
                     .environmentObject(notificationViewModel)
                     .environmentObject(recordViewModel)
+					.environmentObject(searchPostsViewModel)
             } else {
                 unauthenticatedMypageView(selectedTabIndex: $selectedTabIndex)
             }

--- a/JUDA/View/DrinkInfo/DrinkDetail/TaggedTrendingPosts.swift
+++ b/JUDA/View/DrinkInfo/DrinkDetail/TaggedTrendingPosts.swift
@@ -28,6 +28,7 @@ struct TaggedTrendingPosts: View {
                     NavigationLink {
                         PostDetailView(postUserType: post.userField.userID == authService.uid ? .writter : .reader,
                                        post: post,
+									   usedTo: .drinkDetail,
 									   postPhotosURL: post.postField.imagesURL)
                     } label: {
                         if !isLoading {

--- a/JUDA/View/Liked/LikedPostGrid.swift
+++ b/JUDA/View/Liked/LikedPostGrid.swift
@@ -53,6 +53,7 @@ struct LikedPostGridContent: View {
                     NavigationLink {
                         PostDetailView(postUserType: authService.uid == post.userField.userID ? .writter : .reader,
                                        post: post,
+									   usedTo: .liked,
 									   postPhotosURL: post.postField.imagesURL)
                     } label: {
 						PostCell(usedTo: .liked, post: post)

--- a/JUDA/View/Main/PostTopView.swift
+++ b/JUDA/View/Main/PostTopView.swift
@@ -35,6 +35,7 @@ struct PostTopView: View {
                 NavigationLink {
                     PostDetailView(postUserType: authService.uid == post.userField.userID ? .writter : .reader,
                                    post: post,
+								   usedTo: .drinkDetail,
 								   postPhotosURL: post.postField.imagesURL)
                 } label: {
                     PostListCell(post: post,

--- a/JUDA/View/Posts/PostDetail/PostDetailView.swift
+++ b/JUDA/View/Posts/PostDetail/PostDetailView.swift
@@ -14,10 +14,12 @@ enum PostUserType {
 // MARK: - 술상 디테일 화면
 struct PostDetailView: View {
 	@EnvironmentObject private var postsViewModel: PostsViewModel
+	@EnvironmentObject private var searchPostsViewModel: SearchPostsViewModel
 	@Environment(\.dismiss) var dismiss
 	
 	let postUserType: PostUserType
 	let post: Post
+	let usedTo: WhereUsedPostGridContent
 	let postPhotosURL: [URL]
 	
 	@State private var isReportPresented = false
@@ -29,16 +31,16 @@ struct PostDetailView: View {
             // MARK: iOS 16.4 이상
             if #available(iOS 16.4, *) {
                 ScrollView {
-					PostDetailContent(post: post, postPhotosURL: postPhotosURL)
+					PostDetailContent(post: post, usedTo: usedTo, postPhotosURL: postPhotosURL)
                 }
                 .scrollBounceBehavior(.basedOnSize, axes: .vertical)
                 // MARK: iOS 16.4 미만
             } else {
                 ViewThatFits(in: .vertical) {
-					PostDetailContent(post: post, postPhotosURL: postPhotosURL)
+					PostDetailContent(post: post, usedTo: usedTo, postPhotosURL: postPhotosURL)
                         .frame(maxHeight: .infinity, alignment: .top)
                     ScrollView {
-						PostDetailContent(post: post, postPhotosURL: postPhotosURL)
+						PostDetailContent(post: post, usedTo: usedTo, postPhotosURL: postPhotosURL)
                     }
                 }
             }
@@ -139,6 +141,7 @@ struct PostDetailView: View {
 			return
 		}
 		await postsViewModel.postDelete(userID: userID, postID: postID)
+		await searchPostsViewModel.fetchPosts()
 	}
 	
 	private func postReFetch() async {
@@ -156,12 +159,13 @@ struct PostDetailView: View {
 struct PostDetailContent: View {
 	@EnvironmentObject private var postsViewModel: PostsViewModel
 	let post: Post
+	let usedTo: WhereUsedPostGridContent
 	let postPhotosURL: [URL]
 	
     var body: some View {
         VStack {
             // Bar 형태로 된 게시글 정보를 보여주는 뷰
-			PostInfo(post: post)
+			PostInfo(post: post, usedTo: usedTo)
 			// 게시글의 사진을 페이징 스크롤 형식으로 보여주는 뷰
 			PostPhotoScroll(postPhotosURL: postPhotosURL)
 			// 술 평가 + 글 + 음식 태그

--- a/JUDA/View/Posts/PostDetail/PostTags.swift
+++ b/JUDA/View/Posts/PostDetail/PostTags.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 // MARK: - 술상 디테일에서, 음식 태그 부분
 struct PostTags: View {
+	@EnvironmentObject private var searchPostsViewModel: SearchPostsViewModel
 	let tags: [String]
 	@State private var windowWidth: CGFloat = 0
 	
@@ -24,7 +25,7 @@ struct PostTags: View {
 						NavigationLink {
                             // TODO: NavigationLink - value 로 수정
                             // TODO: 태그 값 서치바로 전달해서 검색된 화면으로..!
-							NavigationPostsView(usedTo: .postSearch, searchTagType: .foodTag)
+							NavigationPostsView(usedTo: .postFoodTag, searchTagType: .foodTag, selectedFoodTag: tag)
 						} label: {
 							Text("# \(tag)")
 								.font(.semibold14)

--- a/JUDA/View/Posts/PostsView.swift
+++ b/JUDA/View/Posts/PostsView.swift
@@ -116,12 +116,14 @@ struct PostsView: View {
 					.tabViewStyle(.page(indexDisplayMode: .never))
 				}
 			}
+			// 키보드 내리기
+			.onTapGesture {
+				isFocused = false
+			}
 			.task {
 				if postsViewModel.posts.isEmpty {
 					await postFirstFetch()
 				}
-			}
-			.task {
 				// TODO: search용도 posts 배열에 게시글 패치
 				if searchPostsViewModel.posts.isEmpty {
 					await searchPostsViewModel.fetchPosts()

--- a/JUDA/View/Record/RecordView.swift
+++ b/JUDA/View/Record/RecordView.swift
@@ -19,6 +19,7 @@ struct RecordView: View {
     @EnvironmentObject private var auth: AuthService
     @EnvironmentObject private var recordViewModel: RecordViewModel
 	@EnvironmentObject private var postsViewModel: PostsViewModel
+	@EnvironmentObject private var searchPostsViewModel: SearchPostsViewModel
     // 기록 타입 ( 작성 or 수정 )
     let recordType: RecordType
     // TextEditor focus 상태 프로퍼티
@@ -141,6 +142,8 @@ struct RecordView: View {
 															 likedCount: 0, postedTimeStamp: Date(), foodTags: recordViewModel.foodTags))
 			// post upload
 			await recordViewModel.uploadPost()
+			
+			await searchPostsViewModel.fetchPosts()
 			// loadingView 없애기
 			recordViewModel.isPostUploadSuccess = false
 		} catch {

--- a/JUDA/ViewModel/Posts/PostsViewModel.swift
+++ b/JUDA/ViewModel/Posts/PostsViewModel.swift
@@ -220,15 +220,18 @@ extension PostsViewModel {
 
 // MARK: Update
 extension PostsViewModel {
-	func postLikedUpdate(likeType: LikedActionType, postID: String) async {
+	func postLikedUpdate(likeType: LikedActionType, postID: String, userID: String) async {
 		do {
 			let postDocument = db.collection("posts").document(postID)
 			let postField = try await postDocument.getDocument().data(as: PostField.self)
+			let userPostsDocument = db.collection("users").document(userID).collection("posts").document(postID)
 			switch likeType {
 			case .plus:
 				try await postDocument.updateData(["likedCount": (postField.likedCount + 1)])
+				try await userPostsDocument.updateData(["likedCount": (postField.likedCount + 1)])
 			case .minus:
 				try await postDocument.updateData(["likedCount": (postField.likedCount - 1)])
+				try await userPostsDocument.updateData(["likedCount": (postField.likedCount - 1)])
 			}
 			
 		} catch {

--- a/JUDA/ViewModel/Posts/SearchPostsViewModel.swift
+++ b/JUDA/ViewModel/Posts/SearchPostsViewModel.swift
@@ -42,6 +42,7 @@ class SearchPostsViewModel: ObservableObject {
 	@Published var postSearchText = ""
 	//
 	@Published var searchTagType: SearchTagType = .userName
+	@Published var foodTag: String?
 	// 게시글 정렬 타입
 	let postSortType = PostSortType.allCases
 }
@@ -118,7 +119,7 @@ extension SearchPostsViewModel {
 
 		// 인덱스를 제거하고 최종 결과를 추출
 		let posts = results.map { $1 }
-		self.posts.append(contentsOf: posts)
+		self.posts = posts
 		
 		self.isLoading = false
 	}


### PR DESCRIPTION
## 개요 (이슈 번호 및 요약)
- #119 
## 변경 사항 (작업 내용)
- 포스트 삭제(파이어스토어) 및 해당 포스트 관련 이미지 삭제(파이어 스토리지) 구현 완료
- 신고 기능
- 포스트 검색 기능 구현(유저이름/술 태그/음식 태그)
    - 검색 후 들어간 내비게이션용 포스트뷰에서 좋아요 버튼을 클릭했을 때 앱 내 데이터 업데이트 에러
    - 로직 변경 → 검색 뷰모델에서 사용되는 모든 배열의 값을 변경
    - 커스텀 세그먼트에서 인덱스 변경 시 인기순/최신순 정렬이 되지 않는 현상이 있었고 해결 완료 → 서로 다른 프로퍼티를 사용하고 있었음
    - 서치된 포스트뷰에서 사용되는 데이터들의 업데이트가 이뤄지지 않았고 해결 완료. → 포스트 업로드/삭제/리프레시 될 때 서치포스트에서 사용되는 데이터도 함께 데이터를 업데이트
    - 포스트 삭제, 이미지 삭제, 검색 기능(자잘한 오류 해결코드 제외) 구현 후 머지 완료.
    - 포스트 디테일 뷰의 태그들을 탭 할 경우 네비게이션으로 해당 음식 태그로 포스트 검색해서 불러오는 뷰 구현 완료.
## 스크린샷

## 특이사항 (트러블 슈팅 과정 및 참고 자료 등)
- withTaskGroup 이 놈 확실히 코드의 가독성이나 효율성 면에서는 좋다. 작업 처리 속도도 전보다 확실히 빠른 건 알겠다. 그치만 아직까지는 다루기가 너무 어려워서 많이 써보고 손에 익혀보고싶어졌다.