### PR TITLE
Refactoring/record view model

### DIFF
--- a/JUDA.xcodeproj/project.pbxproj
+++ b/JUDA.xcodeproj/project.pbxproj
@@ -84,6 +84,7 @@
 		2C63DD612B67D5EB00770E3A /* PhotoSelectPagingTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C63DD602B67D5EB00770E3A /* PhotoSelectPagingTab.swift */; };
 		2C63DD652B67DFA400770E3A /* DrinkTagScroll.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C63DD642B67DFA400770E3A /* DrinkTagScroll.swift */; };
 		2C63DD672B67EB1B00770E3A /* RecordView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C63DD662B67EB1B00770E3A /* RecordView.swift */; };
+		2C69CDAC2B9DF61600F70F80 /* RecordViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C69CDAB2B9DF61600F70F80 /* RecordViewModel.swift */; };
 		2C7FD5522B848EEF00169512 /* Post.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C7FD5512B848EEF00169512 /* Post.swift */; };
 		2CACB53C2B99BAC500DD6DCE /* FireStorageService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CACB53B2B99BAC500DD6DCE /* FireStorageService.swift */; };
 		7B0A8BC52B8C163E00740E61 /* Report.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B0A8BC42B8C163E00740E61 /* Report.swift */; };
@@ -100,7 +101,6 @@
 		7B6D76B52B67D5F900601B55 /* PostTags.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B6D76B42B67D5F900601B55 /* PostTags.swift */; };
 		7B6D76B92B68D9C900601B55 /* PostReportView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B6D76B82B68D9C900601B55 /* PostReportView.swift */; };
 		7B74FA5B2B9A9EE800BAC2AC /* PostViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B74FA5A2B9A9EE800BAC2AC /* PostViewModel.swift */; };
-		7B74FA5D2B9ABF7600BAC2AC /* RecordViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B74FA5C2B9ABF7600BAC2AC /* RecordViewModel.swift */; };
 		7B881CA32B97464200571352 /* FirestorePostService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B881CA22B97464200571352 /* FirestorePostService.swift */; };
 		7B881CA52B97545700571352 /* FirestoreDrinkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B881CA42B97545700571352 /* FirestoreDrinkService.swift */; };
 		7B904C662B6168C60052384A /* PostCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B904C652B6168C60052384A /* PostCell.swift */; };
@@ -174,7 +174,7 @@
 		B1EE24922B61447F007F68B0 /* MainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1EE24912B61447F007F68B0 /* MainView.swift */; };
 		B1EE24942B614485007F68B0 /* LogInView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1EE24932B614485007F68B0 /* LogInView.swift */; };
 		B1EE24982B6144BD007F68B0 /* ExLikedViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1EE24972B6144BD007F68B0 /* ExLikedViewModel.swift */; };
-		B1EE249A2B6144C5007F68B0 /* RecordViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1EE24992B6144C5007F68B0 /* RecordViewModel.swift */; };
+		B1EE249A2B6144C5007F68B0 /* ExRecordViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1EE24992B6144C5007F68B0 /* ExRecordViewModel.swift */; };
 		B1EE249C2B6144CD007F68B0 /* ExPostsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1EE249B2B6144CD007F68B0 /* ExPostsViewModel.swift */; };
 		B1EE249E2B6144DD007F68B0 /* ExDrinkViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1EE249D2B6144DD007F68B0 /* ExDrinkViewModel.swift */; };
 		B1EE24A52B614872007F68B0 /* SearchBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1EE24A42B614872007F68B0 /* SearchBar.swift */; };
@@ -255,6 +255,7 @@
 		2C63DD602B67D5EB00770E3A /* PhotoSelectPagingTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoSelectPagingTab.swift; sourceTree = "<group>"; };
 		2C63DD642B67DFA400770E3A /* DrinkTagScroll.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrinkTagScroll.swift; sourceTree = "<group>"; };
 		2C63DD662B67EB1B00770E3A /* RecordView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordView.swift; sourceTree = "<group>"; };
+		2C69CDAB2B9DF61600F70F80 /* RecordViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordViewModel.swift; sourceTree = "<group>"; };
 		2C7FD5512B848EEF00169512 /* Post.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Post.swift; sourceTree = "<group>"; };
 		2CACB53B2B99BAC500DD6DCE /* FireStorageService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FireStorageService.swift; sourceTree = "<group>"; };
 		7B0A8BC42B8C163E00740E61 /* Report.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Report.swift; sourceTree = "<group>"; };
@@ -272,7 +273,6 @@
 		7B6D76B62B68972000601B55 /* PostGrid.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostGrid.swift; sourceTree = "<group>"; };
 		7B6D76B82B68D9C900601B55 /* PostReportView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostReportView.swift; sourceTree = "<group>"; };
 		7B74FA5A2B9A9EE800BAC2AC /* PostViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostViewModel.swift; sourceTree = "<group>"; };
-		7B74FA5C2B9ABF7600BAC2AC /* RecordViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordViewModel.swift; sourceTree = "<group>"; };
 		7B881CA22B97464200571352 /* FirestorePostService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirestorePostService.swift; sourceTree = "<group>"; };
 		7B881CA42B97545700571352 /* FirestoreDrinkService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirestoreDrinkService.swift; sourceTree = "<group>"; };
 		7B904C652B6168C60052384A /* PostCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostCell.swift; sourceTree = "<group>"; };
@@ -323,7 +323,7 @@
 		B1EE24912B61447F007F68B0 /* MainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainView.swift; sourceTree = "<group>"; };
 		B1EE24932B614485007F68B0 /* LogInView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogInView.swift; sourceTree = "<group>"; };
 		B1EE24972B6144BD007F68B0 /* ExLikedViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExLikedViewModel.swift; sourceTree = "<group>"; };
-		B1EE24992B6144C5007F68B0 /* RecordViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordViewModel.swift; sourceTree = "<group>"; };
+		B1EE24992B6144C5007F68B0 /* ExRecordViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExRecordViewModel.swift; sourceTree = "<group>"; };
 		B1EE249B2B6144CD007F68B0 /* ExPostsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExPostsViewModel.swift; sourceTree = "<group>"; };
 		B1EE249D2B6144DD007F68B0 /* ExDrinkViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExDrinkViewModel.swift; sourceTree = "<group>"; };
 		B1EE24A42B614872007F68B0 /* SearchBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchBar.swift; sourceTree = "<group>"; };
@@ -727,7 +727,8 @@
 		B1EE24822B6143D2007F68B0 /* Record */ = {
 			isa = PBXGroup;
 			children = (
-				B1EE24992B6144C5007F68B0 /* RecordViewModel.swift */,
+				B1EE24992B6144C5007F68B0 /* ExRecordViewModel.swift */,
+				2C69CDAB2B9DF61600F70F80 /* RecordViewModel.swift */,
 			);
 			path = Record;
 			sourceTree = "<group>";
@@ -740,7 +741,6 @@
 				7B881CA22B97464200571352 /* FirestorePostService.swift */,
 				7B74FA5A2B9A9EE800BAC2AC /* PostViewModel.swift */,
 				096F2D5C2B9C583E00DFC5A3 /* FirestoreReportService.swift */,
-				7B74FA5C2B9ABF7600BAC2AC /* RecordViewModel.swift */,
 			);
 			path = Posts;
 			sourceTree = "<group>";
@@ -921,7 +921,6 @@
 				7BBDFF6F2B6B90EB0036FB8B /* AddTagView.swift in Sources */,
 				09A320162B8B30D100DE4646 /* ExSearchDrinkViewModel.swift in Sources */,
 				7BBDFF702B6B90EB0036FB8B /* PostGrid.swift in Sources */,
-				7B74FA5D2B9ABF7600BAC2AC /* RecordViewModel.swift in Sources */,
 				7B881CA52B97545700571352 /* FirestoreDrinkService.swift in Sources */,
 				090FF1CE2B83413100AF22B5 /* CustomLoadingView.swift in Sources */,
 				2C5B0F422B6B10CF005F1A99 /* CustomDialog.swift in Sources */,
@@ -946,7 +945,7 @@
 				7B881CA32B97464200571352 /* FirestorePostService.swift in Sources */,
 				0974A1502B8B7B6C00476199 /* ShimmerPostCell.swift in Sources */,
 				09F869B52B6A47B700A56A4C /* AlarmStoreListCell.swift in Sources */,
-				B1EE249A2B6144C5007F68B0 /* RecordViewModel.swift in Sources */,
+				B1EE249A2B6144C5007F68B0 /* ExRecordViewModel.swift in Sources */,
 				2C63DD672B67EB1B00770E3A /* RecordView.swift in Sources */,
 				AC797BDA2B8B8BEB0018D227 /* DrinkTopView.swift in Sources */,
 				7B6D76AF2B67CFC900601B55 /* PostInfo.swift in Sources */,
@@ -1003,6 +1002,7 @@
 				096F2D5B2B9B044400DFC5A3 /* DrinkViewModel.swift in Sources */,
 				099912652B85799800E72C73 /* CircularLoaderView.swift in Sources */,
 				09BCC1582B7C805400FF4D1B /* UserAgreementView.swift in Sources */,
+				2C69CDAC2B9DF61600F70F80 /* RecordViewModel.swift in Sources */,
 				AC7EA1D92B8D77EE00E3E5EC /* Bundle +.swift in Sources */,
 				B121A5722B5F8EE100667D42 /* Font +.swift in Sources */,
 				B1EE249C2B6144CD007F68B0 /* ExPostsViewModel.swift in Sources */,

--- a/JUDA/Model/Drink.swift
+++ b/JUDA/Model/Drink.swift
@@ -23,7 +23,7 @@ struct Drink {
 	let drinkField: DrinkField
 	let taggedPosts: [Post]
 	let agePreference: AgePreference
-	let GenderPreference: GenderPreference
+	let genderPreference: GenderPreference
 	let likedUsersID: [String]
 }
 

--- a/JUDA/Model/Drink.swift
+++ b/JUDA/Model/Drink.swift
@@ -30,7 +30,7 @@ struct Drink {
 // MARK: - Firebase에서 사용하는 Drink Model
 struct DrinkField: Codable, Hashable {
 	@DocumentID var drinkID: String?
-    let drinkImageURL: URL
+    let drinkImageURL: URL?
 	let category: String
 	let type: String
 	let name: String

--- a/JUDA/Model/Post.swift
+++ b/JUDA/Model/Post.swift
@@ -29,6 +29,8 @@ struct PostField: Codable {
 struct WrittenUser: Codable {
     var userID: String
     var userName: String
+    var userAge: Int
+    var userGender: String
     var userProfileImageURL: URL
 }
 

--- a/JUDA/Resource/Components/DrinkListCell.swift
+++ b/JUDA/Resource/Components/DrinkListCell.swift
@@ -19,13 +19,12 @@ enum WhereUsedDrinkListCell {
 
 // MARK: - 술 리스트 셀
 struct DrinkListCell: View {
-    @EnvironmentObject private var authService: AuthService
+//    @EnvironmentObject private var authService: AuthService
+    @EnvironmentObject private var authViewModel: AuthViewModel
     @EnvironmentObject private var mainViewModel: MainViewModel
     @EnvironmentObject private var drinkViewModel: DrinkViewModel
-    @EnvironmentObject private var likedViewModel: LikedViewModel
-    @EnvironmentObject private var searchDrinkViewModel: SearchDrinkViewModel
 
-    let drink: FBDrink
+    let drink: Drink
     var usedTo: WhereUsedDrinkListCell = .drinkInfo
     
     @State private var isLiked = false
@@ -37,17 +36,7 @@ struct DrinkListCell: View {
             // 술 정보
             HStack(alignment: .center, spacing: 20) {
                 // 술 사진
-                if usedTo == .main,
-                   let url = mainViewModel.drinkImages[drink.drinkID ?? ""] {
-                    DrinkListCellKFImage(url: url)
-                } else if usedTo == .searchTag,
-                   let url = searchDrinkViewModel.searchDrinksImageURL[drink.drinkID ?? ""] {
-                    DrinkListCellKFImage(url: url)
-                } else if usedTo == .liked,
-                   let url = likedViewModel.drinkImages[drink.drinkID ?? ""] {
-                    DrinkListCellKFImage(url: url)
-                } else if usedTo == .drinkInfo,
-                    let url = drinkViewModel.drinkImages[drink.drinkID ?? ""] {
+                if let url = drink.drinkField.drinkImageURL {
                     DrinkListCellKFImage(url: url)
                 } else {
                     Text("No Image")
@@ -58,28 +47,28 @@ struct DrinkListCell: View {
                 // 술 이름 + 나라, 도수 + 별점
                 VStack(alignment: .leading, spacing: 10) {
                     // 술 이름 + 용량
-                    Text(drink.name + " " + drink.amount)
+                    Text(drink.drinkField.name + " " + drink.drinkField.amount)
                         .lineLimit(2)
                         .multilineTextAlignment(.leading)
                         .font(.semibold16)
                         .foregroundStyle(.mainBlack)
                     // 나라, 도수
                     HStack(spacing: 0) {
-                        Text(drink.country)
+                        Text(drink.drinkField.country)
                             .font(.semibold14)
-                        if drink.category == DrinkType.wine.rawValue,
-                            let province = drink.province {
+                        if drink.drinkField.category == DrinkType.wine.rawValue,
+                           let province = drink.drinkField.province {
                             Text(province)
                                 .font(.semibold14)
                                 .padding(.leading, 6)
                         }
-                        Text(Formatter.formattedABVCount(abv: drink.alcohol))
+                        Text(Formatter.formattedABVCount(abv: drink.drinkField.alcohol))
                             .font(.semibold14)
                             .padding(.leading, 10)
                     }
                     .foregroundStyle(.gray01)
                     // 별점
-                    StarRating(rating: drink.rating,
+                    StarRating(rating: drink.drinkField.rating,
                                color: .mainAccent05,
                                starSize: .semibold14, 
                                fontSize: .semibold14,
@@ -97,8 +86,21 @@ struct DrinkListCell: View {
                     isLiked.toggle()
                     // 디바운서 콜
                     debouncer.call {
-                        authService.addOrRemoveToLikedDrinks(isLiked: isLiked, drink.drinkID)
-                        authService.userLikedListUpdate(type: .drinks)
+                        // drinks/likedUsersID에 userID를 id로 가진 빈 document 추가/삭제
+                        // user/likedDrinks는 클라우드 펑션으로 처리
+                        Task {
+                            if let drinkID = drink.drinkField.drinkID,
+                               let userID = authViewModel.currentUser?.userField.userID {
+                                if isLiked {
+                                    await drinkViewModel.addOrRemoveToLikedUsersID(likedAction: .plus, drinkID: drinkID, userID: userID)
+                                    authViewModel.currentUser?.likedDrinks.append(drink)
+                                    
+                                } else {
+                                    await drinkViewModel.addOrRemoveToLikedUsersID(likedAction: .minus, drinkID: drinkID, userID: userID)
+                                    authViewModel.currentUser?.likedDrinks.removeAll(where: { $0.drinkField.drinkID == drinkID })
+                                }
+                            }
+                        }
                     }
                 } label: {
                     Image(systemName: isLiked ? "heart.fill" : "heart")
@@ -110,8 +112,8 @@ struct DrinkListCell: View {
         .padding(.horizontal, 20)
         .frame(height: 130)
 		.task {
-            if let user = authService.currentUser {
-                self.isLiked = user.likedDrinks.contains { $0 == drink.drinkID }
+            if let user = authViewModel.currentUser {
+                self.isLiked = user.likedDrinks.contains { $0.drinkField.drinkID == drink.drinkField.drinkID }
             }
 		}
     }

--- a/JUDA/Resource/Components/DrinkListCell.swift
+++ b/JUDA/Resource/Components/DrinkListCell.swift
@@ -89,17 +89,7 @@ struct DrinkListCell: View {
                         // drinks/likedUsersID에 userID를 id로 가진 빈 document 추가/삭제
                         // user/likedDrinks는 클라우드 펑션으로 처리
                         Task {
-                            if let drinkID = drink.drinkField.drinkID,
-                               let userID = authViewModel.currentUser?.userField.userID {
-                                if isLiked {
-                                    await drinkViewModel.addOrRemoveToLikedUsersID(likedAction: .plus, drinkID: drinkID, userID: userID)
-                                    authViewModel.currentUser?.likedDrinks.append(drink)
-                                    
-                                } else {
-                                    await drinkViewModel.addOrRemoveToLikedUsersID(likedAction: .minus, drinkID: drinkID, userID: userID)
-                                    authViewModel.currentUser?.likedDrinks.removeAll(where: { $0.drinkField.drinkID == drinkID })
-                                }
-                            }
+                            await authViewModel.updateLikedDrinks(isLiked: isLiked, sellectedDrink: drink)
                         }
                     }
                 } label: {

--- a/JUDA/View/Record/AddTagView.swift
+++ b/JUDA/View/Record/AddTagView.swift
@@ -11,7 +11,6 @@ import PhotosUI
 // MARK: - 글 작성 시, 사진 선택 및 술 태그 추가 화면
 struct AddTagView: View {
     @EnvironmentObject private var navigationRouter: NavigationRouter
-//    @EnvironmentObject private var auth: AuthService
     @EnvironmentObject private var recordViewModel: RecordViewModel
     // 사진 배열
     @State private var selectedPhotos: [PhotosPickerItem] = []

--- a/JUDA/View/Record/AddTagView.swift
+++ b/JUDA/View/Record/AddTagView.swift
@@ -11,7 +11,7 @@ import PhotosUI
 // MARK: - 글 작성 시, 사진 선택 및 술 태그 추가 화면
 struct AddTagView: View {
     @EnvironmentObject private var navigationRouter: NavigationRouter
-    @EnvironmentObject private var auth: AuthService
+//    @EnvironmentObject private var auth: AuthService
     @EnvironmentObject private var recordViewModel: RecordViewModel
     // 사진 배열
     @State private var selectedPhotos: [PhotosPickerItem] = []
@@ -68,7 +68,7 @@ struct AddTagView: View {
                 if isShowRatingDialog {
                     CustomDialog(type: .rating(
                         // 선택된 술 태그의 술 이름
-                        drinkName: recordViewModel.selectedDrinkTag?.drink.name ?? "",
+                        drinkName: recordViewModel.selectedDrinkTag?.drinkName ?? "",
                         leftButtonLabel: "취소",
                         leftButtonAction: {
                             // CustomRatingDialog 사라지게 하기
@@ -80,8 +80,8 @@ struct AddTagView: View {
                             if rating > 0 {
                                 // 술 태그 배열에서 해당 술 태그의 점수를 변경
 								if let selectedDrinkTag = recordViewModel.selectedDrinkTag,
-								   let index = recordViewModel.drinkTags.firstIndex(where: { $0.drink.drinkID == selectedDrinkTag.drink.drinkID }) {
-									recordViewModel.drinkTags[index] = DrinkTag(drink: selectedDrinkTag.drink, rating: rating)
+                                   let index = recordViewModel.drinkTags.firstIndex(where: { $0.drinkID ==  selectedDrinkTag.drinkID }) {
+                                    recordViewModel.drinkTags[index] = DrinkTag(drinkID: selectedDrinkTag.drinkID, drinkName: selectedDrinkTag.drinkName, drinkAmount: selectedDrinkTag.drinkAmount, drinkRating: rating)
                                 }
                                 // 점수 변경 후 CustomRatingDialog 사라지게 하기
                                 isShowRatingDialog = false
@@ -92,7 +92,7 @@ struct AddTagView: View {
                     )
                     // 선택한 drinkTag의 rating을 CustomDialog에 표시하기 위한 rating 값 변경
                     .onAppear {
-						if let rating = recordViewModel.selectedDrinkTag?.rating {
+                        if let rating = recordViewModel.selectedDrinkTag?.drinkRating {
                             self.rating = rating
                         }
                     }

--- a/JUDA/View/Record/DrinkTagScroll.swift
+++ b/JUDA/View/Record/DrinkTagScroll.swift
@@ -40,7 +40,7 @@ struct DrinkTagContent: View {
     
     var body: some View {
         LazyVStack {
-			ForEach(recordViewModel.drinkTags, id: \.drink.drinkID) { drinkTag in
+            ForEach(recordViewModel.drinkTags, id: \.drinkID) { drinkTag in
                 DrinkTagCell(drinkTag: drinkTag)
                     .onTapGesture {
                         // 현재 선택된 DrinkTagCell의 술 태그 정보 받아오기
@@ -64,7 +64,7 @@ struct DrinkTagCell: View {
             VStack(spacing: 10) {
                 HStack {
                     // 술 이름
-					Text(drinkTag.drink.name)
+					Text(drinkTag.drinkName)
                         .font(.semibold16)
                         .lineLimit(1)
                         .padding(.trailing, 40)
@@ -74,7 +74,7 @@ struct DrinkTagCell: View {
                 HStack(alignment: .center) {
                     Text("나의 평가")
                         .font(.regular16)
-                    StarRating(rating: drinkTag.rating,
+                    StarRating(rating: drinkTag.drinkRating,
                                color: .mainAccent03,
                                starSize: .regular20,
                                fontSize: nil,
@@ -86,7 +86,7 @@ struct DrinkTagCell: View {
             // Xmark 버튼
             Button {
                 // 클릭 시, 술 태그 배열에서 해당 술 태그 삭제
-				recordViewModel.drinkTags.removeAll(where: { $0.drink.drinkID == drinkTag.drink.drinkID })
+                recordViewModel.drinkTags.removeAll(where: { $0.drinkID == drinkTag.drinkID })
             } label: {
                 Image(systemName: "xmark")
                     .foregroundStyle(.gray01)

--- a/JUDA/View/Record/PhotoSelectPagingTab.swift
+++ b/JUDA/View/Record/PhotoSelectPagingTab.swift
@@ -37,9 +37,9 @@ struct PhotoSelectPagingTab: View {
             // 선택된 사진들을 탭뷰 페이징 형식으로 보여주기
             TabView(selection: $selectedIndex) {
                 Group {
-                    ForEach(recordViewModel.images.indices, id: \.self) { index in
+                    ForEach(recordViewModel.selectedImages.indices, id: \.self) { index in
                         // 이미지
-                        Image(uiImage: recordViewModel.images[index])
+                        Image(uiImage: recordViewModel.selectedImages[index])
                             .resizable()
                             .aspectRatio(contentMode: .fill)
                             .frame(width: imageSize, height: imageSize)
@@ -56,14 +56,14 @@ struct PhotoSelectPagingTab: View {
                             .tag(index + 1)
                     }
                     // 선택된 사진이 10장보다 적을 때,
-                    if recordViewModel.images.count < maxImages {
+                    if recordViewModel.selectedImages.count < maxImages {
                         // 사진 선택 (포토픽커)
                         LibraryPhotosPicker(selectedPhotos: $selectedPhotos, maxSelectionCount: maxImages) {
                             Image(systemName: "plus.circle.fill")
                                 .font(.largeTitle)
                                 .frame(width: imageSize, height: imageSize)
                                 .background(.gray06)
-                        }.tag(recordViewModel.images.count + 1)
+                        }.tag(recordViewModel.selectedImages.count + 1)
                     }
                 }
             }
@@ -81,9 +81,9 @@ struct PhotoSelectPagingTab: View {
                 }
             }
             // 현재 보이는 사진 맨 뒤 사진으로 수정
-            .onChange(of: recordViewModel.images) { _ in
+            .onChange(of: recordViewModel.selectedImages) { _ in
                 Task {
-                    selectedIndex = recordViewModel.images.count
+                    selectedIndex = recordViewModel.selectedImages.count
                 }
             }
         }
@@ -93,7 +93,7 @@ struct PhotoSelectPagingTab: View {
     private func updateImage() async throws {
         // 선택된 사진 하나도 없으면, 배열 비우고 바로 리턴
         guard !selectedPhotos.isEmpty else {
-            recordViewModel.images = []
+            recordViewModel.selectedImages = []
             return
         }
         var images = [UIImage]() // 임시 배열 (작업 끝나면 배열채로 한번에 업데이트
@@ -109,12 +109,12 @@ struct PhotoSelectPagingTab: View {
                 throw PhotosPickerImageLoadingError.invalidImageData
             }
         }
-        recordViewModel.images = images
-        self.selectedIndex = recordViewModel.images.count
+        recordViewModel.selectedImages = images
+        self.selectedIndex = recordViewModel.selectedImages.count
     }
     
     private func removePhoto(_ index: Int) {
-        recordViewModel.images.remove(at: index)
+        recordViewModel.selectedImages.remove(at: index)
         selectedPhotos.remove(at: index)
     }
 }

--- a/JUDA/View/Record/RecordView.swift
+++ b/JUDA/View/Record/RecordView.swift
@@ -76,7 +76,7 @@ struct RecordView: View {
         .loadingView($recordViewModel.isPostUploading)
         // 글 내용 유무 체크
         .onAppear {
-            recordViewModel.isPostContentNotEmpty()
+            recordViewModel.checkPostContentIsEmpty()
             // TODO: recordType에 따라 recordView에 값 띄워주기
             switch recordType {
             case .add:
@@ -90,7 +90,7 @@ struct RecordView: View {
         }
         // 글 내용 유무 체크
         .onChange(of: recordViewModel.content) { _ in
-            recordViewModel.isPostContentNotEmpty()
+            recordViewModel.checkPostContentIsEmpty()
         }
         .navigationBarBackButtonHidden()
         .toolbar {
@@ -137,8 +137,8 @@ struct RecordView: View {
                     Text("완료")
                         .font(.regular16)
                 }
-                .foregroundStyle(recordViewModel.isPostContent ? .mainBlack : .gray01)
-                .disabled(!recordViewModel.isPostContent)
+                .foregroundStyle(recordViewModel.postContentIsEmpty ? .gray01 : .mainBlack)
+                .disabled(recordViewModel.postContentIsEmpty)
             }
         }
     }

--- a/JUDA/View/Record/SearchTagView.swift
+++ b/JUDA/View/Record/SearchTagView.swift
@@ -10,9 +10,11 @@ import SwiftUI
 // MARK: - 술 태그 서치 시트 화면
 // Defualt로 술찜 목록 보여주기
 struct SearchTagView: View {
-    @StateObject private var searchDrinkViewModel = SearchDrinkViewModel()
-    @EnvironmentObject private var authService: AuthService
+    @EnvironmentObject private var authViewModel: AuthViewModel
     @EnvironmentObject private var recordViewModel: RecordViewModel
+    @EnvironmentObject private var drinkViewModel: DrinkViewModel
+    // drink 검색 결과를 담은 배열
+    @State var searchResult = [Drink]()
     // CostomRatingDialog를 띄워주는 상태 프로퍼티
     @State private var isShowRatingDialog: Bool = false
     // SearchTagView Sheet를 띄워주는 상태 프로퍼티
@@ -31,13 +33,14 @@ struct SearchTagView: View {
                     // 서치바 submit 시, 술 검색
                     SearchBar(inputText: $tagSearchText, isFocused: $isFocused) {
                         Task {
-                            await searchDrinkViewModel.fetchSearchDrinks(from: tagSearchText)
+//                            await searchDrinkViewModel.fetchSearchDrinks(from: tagSearchText)
+                            searchResult = await drinkViewModel.getSearchedDrinks(from: tagSearchText)
                         }
                     }
                     // 서치바 Text가 없을 때, 술 검색 결과 비워주기
                     .onChange(of: tagSearchText) { _ in
                         if tagSearchText == "" {
-                            searchDrinkViewModel.searchDrinks = []
+                            searchResult = []
                         }
                     }
                     // Sheet 내려주기
@@ -64,7 +67,7 @@ struct SearchTagView: View {
                             .frame(maxWidth: .infinity, maxHeight: .infinity)
                     }
                 // 검색 중
-                } else if searchDrinkViewModel.isLoading {
+                } else if drinkViewModel.isLoading {
                     VStack {
                         Rectangle()
                             .fill(.background)
@@ -79,20 +82,17 @@ struct SearchTagView: View {
                     // MARK: iOS 16.4 이상
                     if #available(iOS 16.4, *) {
                         ScrollView() {
-                            SearchTagListContent(isShowRatingDialog: $isShowRatingDialog)
-                                .environmentObject(searchDrinkViewModel)
+                            SearchTagListContent(isShowRatingDialog: $isShowRatingDialog, searchResult: searchResult)
                         }
                         .scrollBounceBehavior(.basedOnSize, axes: .vertical)
                         .scrollDismissesKeyboard(.immediately)
                     // MARK: iOS 16.4 미만
                     } else {
                         ViewThatFits(in: .vertical) {
-                            SearchTagListContent(isShowRatingDialog: $isShowRatingDialog)
-                                .environmentObject(searchDrinkViewModel)
+                            SearchTagListContent(isShowRatingDialog: $isShowRatingDialog, searchResult: searchResult)
                                 .frame(maxHeight: .infinity, alignment: .top)
                             ScrollView {
-                                SearchTagListContent(isShowRatingDialog: $isShowRatingDialog)
-                                    .environmentObject(searchDrinkViewModel)
+                                SearchTagListContent(isShowRatingDialog: $isShowRatingDialog, searchResult: searchResult)
                             }
                             .scrollDismissesKeyboard(.immediately)
                         }
@@ -109,7 +109,7 @@ struct SearchTagView: View {
                 if let selectedDrinkTag = recordViewModel.selectedDrinkTag {
                     CustomDialog(type: .rating(
                         // 선택된 술 정보의 술 이름
-						drinkName: selectedDrinkTag.drink.name,
+                        drinkName: selectedDrinkTag.drinkName,
                         leftButtonLabel: "취소",
                         leftButtonAction: {
                             // CustomRatingDialog 사라지게 하기
@@ -120,11 +120,21 @@ struct SearchTagView: View {
                             // 0보다 큰 점수를 매겼을 때 수정 버튼 동작
                             if rating > 0 {
                                 // dirnkTag 값 변경
-								if let index = recordViewModel.drinkTags.firstIndex(where: { $0.drink.drinkID == selectedDrinkTag.drink.drinkID }) {
-									recordViewModel.drinkTags[index] = DrinkTag(drink: selectedDrinkTag.drink, rating: rating)
-								} else {
-									recordViewModel.drinkTags.append(DrinkTag(drink: selectedDrinkTag.drink, rating: rating))
-								}
+                                let drinkID = selectedDrinkTag.drinkID
+                                let drinkName = selectedDrinkTag.drinkName
+                                let drinkAmount = selectedDrinkTag.drinkAmount
+                                
+                                if let index = recordViewModel.drinkTags.firstIndex(where: { $0.drinkID == drinkID }) {
+                                    recordViewModel.drinkTags[index] = DrinkTag(drinkID: drinkID,
+                                                                                drinkName: drinkName,
+                                                                                drinkAmount: drinkAmount,
+                                                                                drinkRating: rating)
+                                } else {
+                                    recordViewModel.drinkTags.append(DrinkTag(drinkID: drinkID,
+                                                                              drinkName: drinkName,
+                                                                              drinkAmount: drinkAmount,
+                                                                              drinkRating: rating))
+                                }
                                 // 변경 후 CustomRatingDialog, SearchTagView 사라지게 하기
                                 isShowRatingDialog.toggle()
                                 isShowSearchTag.toggle()
@@ -137,27 +147,29 @@ struct SearchTagView: View {
         }
         // SearchTagView Disappear시, 검색 결과 비워주기
         .onDisappear {
-            searchDrinkViewModel.searchDrinks = []
+            searchResult = []
         }
     }
 }
 
 // MARK: - 스크롤 뷰 or 뷰 로 보여질 태그 추가 시, DrinkListCell 리스트
 struct SearchTagListContent: View {
-    @EnvironmentObject private var authService: AuthService
+//    @EnvironmentObject private var authService: AuthService
     @EnvironmentObject private var recordViewModel: RecordViewModel
-    @EnvironmentObject private var searchDrinkViewModel: SearchDrinkViewModel
+//    @EnvironmentObject private var searchDrinkViewModel: SearchDrinkViewModel
     // CostomRatingDialog를 띄워주는 상태 프로퍼티
     @Binding var isShowRatingDialog: Bool
+    // drink 검색 결과 배열
+    let searchResult: [Drink]
         
     var body: some View {
         LazyVStack {
-            ForEach(searchDrinkViewModel.searchDrinks, id: \.drinkID) { drink in
-                DrinkListCell(drink: drink,
-                              usedTo: .searchTag)
+            ForEach(searchResult, id: \.drinkField.drinkID) { drink in
+                DrinkListCell(drink: drink, usedTo: .searchTag)
                     .onTapGesture {
                         // 현재 선택된 DrinkListCell의 술 정보를 받아오기
-                        recordViewModel.selectedDrinkTag = DrinkTag(drink: drink, rating: 0)
+                        guard let drinkID = drink.drinkField.drinkID else { return }
+                        recordViewModel.selectedDrinkTag = DrinkTag(drinkID: drinkID, drinkName: drink.drinkField.name, drinkAmount: drink.drinkField.amount, drinkRating: 0)
                         // CustomRatingDialog 띄우기
                         isShowRatingDialog.toggle()
                     }

--- a/JUDA/View/Record/SearchTagView.swift
+++ b/JUDA/View/Record/SearchTagView.swift
@@ -65,6 +65,7 @@ struct SearchTagView: View {
                             .fill(.background)
                             .frame(maxWidth: .infinity, maxHeight: .infinity)
                     }
+                // TODO: isSearching 사용하여 검색 중 판별하는 걸로 변경
                 // 검색 중
                 } else if drinkViewModel.isLoading {
                     VStack {

--- a/JUDA/View/Record/SearchTagView.swift
+++ b/JUDA/View/Record/SearchTagView.swift
@@ -33,7 +33,6 @@ struct SearchTagView: View {
                     // 서치바 submit 시, 술 검색
                     SearchBar(inputText: $tagSearchText, isFocused: $isFocused) {
                         Task {
-//                            await searchDrinkViewModel.fetchSearchDrinks(from: tagSearchText)
                             searchResult = await drinkViewModel.getSearchedDrinks(from: tagSearchText)
                         }
                     }
@@ -154,9 +153,7 @@ struct SearchTagView: View {
 
 // MARK: - 스크롤 뷰 or 뷰 로 보여질 태그 추가 시, DrinkListCell 리스트
 struct SearchTagListContent: View {
-//    @EnvironmentObject private var authService: AuthService
     @EnvironmentObject private var recordViewModel: RecordViewModel
-//    @EnvironmentObject private var searchDrinkViewModel: SearchDrinkViewModel
     // CostomRatingDialog를 띄워주는 상태 프로퍼티
     @Binding var isShowRatingDialog: Bool
     // drink 검색 결과 배열

--- a/JUDA/View/Record/SelectedPhotoHorizontalScroll.swift
+++ b/JUDA/View/Record/SelectedPhotoHorizontalScroll.swift
@@ -6,25 +6,63 @@
 //
 
 import SwiftUI
+import Kingfisher
 
 // MARK: - 선택된 사진들을 보여주는 스크롤뷰
 struct SelectedPhotoHorizontalScroll: View {
     @EnvironmentObject private var recordViewModel: RecordViewModel
+    // post add/edit
+    let recordType: RecordType
     
     var body: some View {
         ScrollView(.horizontal) {
             LazyHStack(spacing: 10) {
-                ForEach(0..<recordViewModel.images.count, id: \.self) { index in
-                    Image(uiImage: recordViewModel.images[index])
-                        .resizable()
-                        .aspectRatio(contentMode: .fill)
-                        .frame(width: 100, height: 100)
-                        .clipShape(.rect(cornerRadius: 10))
+                switch recordType {
+                // post add
+                case .add:
+                    // 라이브러리에서 선택된 사진 image로 보여주기
+                    ForEach(0..<recordViewModel.selectedImages.count, id: \.self) { index in
+                        Image(uiImage: recordViewModel.selectedImages[index])
+                            .resizable()
+                            .aspectRatio(contentMode: .fill)
+                            .frame(width: 100, height: 100)
+                            .clipShape(.rect(cornerRadius: 10))
+                    }
+                // post edit
+                case .edit:
+                    if let post = recordViewModel.post {
+                        // post가 가진 ImagesURL을 KFImage로 보여주기
+                        ForEach(0..<(post.postField.imagesURL.count), id: \.self) { index in
+                            SelectedImageKFImage(url: post.postField.imagesURL[index])
+                        }
+                    }
                 }
             }
         }
         .frame(height: 120)
         .padding(.leading, 20)
         .padding(.vertical, 10)
+    }
+}
+
+// MARK: - 술 리스트 셀 사용 KingFisher 이미지
+struct SelectedImageKFImage: View {
+    // post가 가진 imageURL
+    let url: URL
+    
+    var body: some View {
+        KFImage.url(url)
+            .placeholder {
+                CircularLoaderView(size: 20)
+                    .frame(width: 100, height: 100)
+            }
+            .loadDiskFileSynchronously(true) // 디스크에서 동기적으로 이미지 가져오기
+            .cancelOnDisappear(true) // 화면 이동 시, 진행중인 다운로드 중단
+            .cacheMemoryOnly() // 메모리 캐시만 사용 (디스크 X)
+            .fade(duration: 0.2) // 이미지 부드럽게 띄우기
+            .resizable()
+            .aspectRatio(contentMode: .fill)
+            .frame(width: 100, height: 100)
+            .clipShape(.rect(cornerRadius: 10))
     }
 }

--- a/JUDA/View/Record/SelectedPhotoHorizontalScroll.swift
+++ b/JUDA/View/Record/SelectedPhotoHorizontalScroll.swift
@@ -46,7 +46,7 @@ struct SelectedPhotoHorizontalScroll: View {
 }
 
 // MARK: - 술 리스트 셀 사용 KingFisher 이미지
-struct SelectedImageKFImage: View {
+private struct SelectedImageKFImage: View {
     // post가 가진 imageURL
     let url: URL
     

--- a/JUDA/ViewModel/App/FireStorageService.swift
+++ b/JUDA/ViewModel/App/FireStorageService.swift
@@ -22,9 +22,13 @@ final class FireStorageService {
     private let imageType = "image/jpg"
 
     // FireStorage 에 이미지 올리기
-    func uploadImageToStorage(folder: FireStorageFolderType, image: UIImage, fileName: String) async throws {
+    func uploadImageToStorage(folder: FireStorageFolderType, userID: String? = nil, postID: String? = nil, image: UIImage, fileName: String) async throws {
         do {
-            let storageRoute = storageRef.child("\(folder.rawValue)/\(fileName)")
+            var storagePath = folder.rawValue
+            if let userID = userID, let postID = postID {
+                storagePath += "/\(userID)/\(postID)"
+            }
+            let storageRoute = storageRef.child("\(storagePath)/\(fileName)")
             let data = Formatter.compressImage(image)
             let metaData = StorageMetadata()
             metaData.contentType = imageType

--- a/JUDA/ViewModel/Drink/DrinkViewModel.swift
+++ b/JUDA/ViewModel/Drink/DrinkViewModel.swift
@@ -178,16 +178,3 @@ extension DrinkViewModel {
         return drinkFieldData.name.localizedCaseInsensitiveContains(keyword)
     }
 }
-
-// MARK: - Upload likedUsersID
-extension DrinkViewModel {
-    func addOrRemoveToLikedUsersID(likedAction: LikedActionType, drinkID: String, userID: String) async {
-        let likedUsersIDRef = db.collection(drinkCollection).document(drinkID).collection("likedUsersID")
-        switch likedAction {
-        case .plus:
-            await firestoreDrinkService.uploadDrinkLikedUsersID(collection: likedUsersIDRef, uid: userID)
-        case .minus:
-            await firestoreDrinkService.deleteDrinkLikedUsersID(collection: likedUsersIDRef, uid: userID)
-        }
-    }
-}

--- a/JUDA/ViewModel/Drink/DrinkViewModel.swift
+++ b/JUDA/ViewModel/Drink/DrinkViewModel.swift
@@ -178,3 +178,16 @@ extension DrinkViewModel {
         return drinkFieldData.name.localizedCaseInsensitiveContains(keyword)
     }
 }
+
+// MARK: - Upload likedUsersID
+extension DrinkViewModel {
+    func addOrRemoveToLikedUsersID(likedAction: LikedActionType, drinkID: String, userID: String) async {
+        let likedUsersIDRef = db.collection(drinkCollection).document(drinkID).collection("likedUsersID")
+        switch likedAction {
+        case .plus:
+            await firestoreDrinkService.uploadDrinkLikedUsersID(collection: likedUsersIDRef, uid: userID)
+        case .minus:
+            await firestoreDrinkService.deleteDrinkLikedUsersID(collection: likedUsersIDRef, uid: userID)
+        }
+    }
+}

--- a/JUDA/ViewModel/Drink/FirestoreDrinkService.swift
+++ b/JUDA/ViewModel/Drink/FirestoreDrinkService.swift
@@ -241,14 +241,4 @@ extension FirestoreDrinkService {
             print(error.localizedDescription)
         }
     }
-    
-    // likedUsersID 하위 컬렉션에 document 삭제
-    func deleteDrinkLikedUsersID(collection: CollectionReference, uid: String) async {
-        do {
-            try await collection.document(uid).delete()
-        } catch {
-            print("error :: deleteDrinkLikedUsersID() -> delete drink liked users id data failure")
-            print(error.localizedDescription)
-        }
-    }
 }

--- a/JUDA/ViewModel/Drink/FirestoreDrinkService.swift
+++ b/JUDA/ViewModel/Drink/FirestoreDrinkService.swift
@@ -69,7 +69,7 @@ extension FirestoreDrinkService {
 			return Drink(drinkField: drikField, 
 						 taggedPosts: taggedPosts,
 						 agePreference: agePreference,
-						 GenderPreference: genderPreference, 
+						 genderPreference: genderPreference,
 						 likedUsersID: likedUsersID)
 		} catch DrinkError.fetchDrinkField {
 			print("error :: fetchDrinkField() -> fetch drink field data failure")
@@ -194,6 +194,26 @@ extension FirestoreDrinkService {
 			return false
 		}
 	}
+}
+
+extension FirestoreDrinkService {
+    // drink collection agePreference data update 메서드
+    func updateDrinkAgePreference(ref: CollectionReference, drinkID: String, age: String, userID: String) async {
+        do {
+            try await ref.document(drinkID).collection("agePreference").document(age).collection(age).document(userID).setData([:])
+        } catch {
+            // TODO: error 처리
+        }
+    }
+    
+    // drink collection genderPreference data update 메서드
+    func updateDrinkGenderPreference(ref: CollectionReference, drinkID: String, gender: String, userID: String) async {
+        do {
+            try await ref.document(drinkID).collection("genderPreference").document(gender).collection(gender).document(userID).setData([:])
+        } catch {
+            // TODO: error 처리
+        }
+    }
 }
 
 // MARK: Firestore drink document delete

--- a/JUDA/ViewModel/Drink/FirestoreDrinkService.swift
+++ b/JUDA/ViewModel/Drink/FirestoreDrinkService.swift
@@ -230,7 +230,7 @@ extension FirestoreDrinkService {
     }
 }
 
-// MARK: Firestore drink document upload
+// MARK: Firestore drink document upload & delete
 extension FirestoreDrinkService {
     // likedUsersID 하위 컬렉션에 업로드
     func uploadDrinkLikedUsersID(collection: CollectionReference, uid: String) async {
@@ -238,6 +238,16 @@ extension FirestoreDrinkService {
             try await collection.document(uid).setData([:])
         } catch {
             print("error :: uploadDrinkLikedUsersID() -> upload drink liked users id data failure")
+            print(error.localizedDescription)
+        }
+    }
+    
+    // likedUsersID 하위 컬렉션에 document 삭제
+    func deleteDrinkLikedUsersID(collection: CollectionReference, uid: String) async {
+        do {
+            try await collection.document(uid).delete()
+        } catch {
+            print("error :: deleteDrinkLikedUsersID() -> delete drink liked users id data failure")
             print(error.localizedDescription)
         }
     }

--- a/JUDA/ViewModel/Drink/FirestoreDrinkService.swift
+++ b/JUDA/ViewModel/Drink/FirestoreDrinkService.swift
@@ -198,20 +198,20 @@ extension FirestoreDrinkService {
 
 extension FirestoreDrinkService {
     // drink collection agePreference data update 메서드
-    func updateDrinkAgePreference(ref: CollectionReference, drinkID: String, age: String, userID: String) async {
+    func updateDrinkAgePreference(ref: CollectionReference, drinkID: String, age: Age, userID: String) async {
         do {
-            try await ref.document(drinkID).collection("agePreference").document(age).collection(age).document(userID).setData([:])
+            try await ref.document(drinkID).collection("agePreference").document(age.rawValue).collection("usersID").document(userID).setData([:])
         } catch {
-            // TODO: error 처리
+            print("error :: updateDrinkAgePreference() -> upload userID to agePreference failure")
         }
     }
     
     // drink collection genderPreference data update 메서드
     func updateDrinkGenderPreference(ref: CollectionReference, drinkID: String, gender: String, userID: String) async {
         do {
-            try await ref.document(drinkID).collection("genderPreference").document(gender).collection(gender).document(userID).setData([:])
+            try await ref.document(drinkID).collection("genderPreference").document(gender).collection("usersID").document(userID).setData([:])
         } catch {
-            // TODO: error 처리
+            print("error :: updateDrinkGenderPreference() -> upload userID to genderPreference failure")
         }
     }
 }

--- a/JUDA/ViewModel/Posts/FirestorePostService.swift
+++ b/JUDA/ViewModel/Posts/FirestorePostService.swift
@@ -93,8 +93,7 @@ extension FirestorePostService {
 
 //MARK: Firestore post document upload
 extension FirestorePostService {
-	func uploadPostDocument(post: Post) async throws {
-		let postID = UUID().uuidString
+    func uploadPostDocument(post: Post, postID: String) async throws {
 		let postDocumentRef = Firestore.firestore().collection("posts").document(postID)
 		let likedUsersIDCollectionRef = postDocumentRef.collection("likedUsersID")
 		

--- a/JUDA/ViewModel/Posts/RecordViewModel.swift
+++ b/JUDA/ViewModel/Posts/RecordViewModel.swift
@@ -1,8 +1,0 @@
-//
-//  RecordService.swift
-//  JUDA
-//
-//  Created by Minjae Kim on 3/8/24.
-//
-
-import Foundation

--- a/JUDA/ViewModel/Record/ExRecordViewModel.swift
+++ b/JUDA/ViewModel/Record/ExRecordViewModel.swift
@@ -1,0 +1,220 @@
+//
+//  RecordViewModel.swift
+//  JUDA
+//
+//  Created by 홍세희 on 2024/01/24.
+//
+
+import SwiftUI
+import FirebaseCore
+import FirebaseFirestore
+import FirebaseStorage
+import PhotosUI
+
+final class ExRecordViewModel: ObservableObject {
+    // post 업로드용 Post 모델 객체
+    @Published var post: Post?
+    // (dirnkID, (drinkData, rating)) 튜플 형태의 선택한 술 Data
+    @Published var selectedDrinkTag: DrinkTag?
+    // [drinkID: (drinkData, rating)] 딕셔너리 형태의 태그된 모든 술 Data
+    @Published var drinkTags: [DrinkTag] = []
+    // 라이브러리에서 선택된 모든 사진 Data
+    @Published var images: [UIImage] = []
+    // 선택된 모든 사진 Data의 ID를 갖는 배열
+    var imagesURL: [URL] = []
+    // 글 내용을 담는 프로퍼티
+    @Published var content: String = ""
+    // 음식 태그를 담는 배열
+    @Published var foodTags: [String] = []
+    // 화면 너비 받아오기
+	var windowWidth: CGFloat {
+		TagHandler.getScreenWidthWithoutPadding(padding: 20)
+	}
+    // post 업로드 완료 확인 및 로딩 뷰 출력용 프로퍼티
+    @Published var isPostUploadSuccess = false
+    
+    // Firestore connection
+    private let db = Firestore.firestore()
+    
+    // FireStorage 기본 경로
+    private let storage = Storage.storage()
+    private let drinkImagesPath = "drinkImages/"
+}
+
+// MARK: - FirebaseStorage Image Upload
+extension ExRecordViewModel {
+	func uploadMultipleImagesToFirebaseStorageAsync(_ imagesData: [Data]) async throws {
+		// 여러 이미지 업로드를 동시에 처리하기 위한 비동기 작업 배열
+		var uploadTasks: [Task<(Int, URL), Error>] = []
+		
+		// 각 이미지 데이터에 대해 비동기 업로드 작업 생성 및 배열에 추가
+		for (index, imageData) in imagesData.enumerated() {
+			let uploadTask = Task { try await uploadImageToFirebaseStorageAsync(imageData, index: index) }
+			uploadTasks.append(uploadTask)
+		}
+
+		// 모든 업로드 작업이 완료될 때까지 기다린 후 결과 URL 배열 반환
+		return try await withThrowingTaskGroup(of: (Int, URL).self, body: { group in
+			var downloadURLs: [(Int, URL)] = []
+			
+			// 각 업로드 작업을 TaskGroup에 추가
+			for task in uploadTasks {
+				group.addTask {
+					// Task의 결과를 반환
+					try await task.value
+				}
+			}
+			
+			// TaskGroup의 모든 결과를 수집
+			for try await downloadURL in group {
+				downloadURLs.append(downloadURL)
+			}
+
+			downloadURLs.sort(by: { $0.0 < $1.0 })
+			self.imagesURL = downloadURLs.map { $0.1 }
+		})
+	}
+
+	func uploadImageToFirebaseStorageAsync(_ imageData: Data, index: Int) async throws -> (Int, URL) {
+		let storageRef = Storage.storage().reference()
+		let imageID = UUID().uuidString  // 고유한 이미지 ID 생성
+		let imageRef = storageRef.child("postImages/\(imageID).jpg")
+
+		let metadata = StorageMetadata()
+		metadata.contentType = "image/jpg"
+		
+		// 이미지 업로드
+		let _ = try await imageRef.putDataAsync(imageData, metadata: metadata)
+		
+		// 업로드된 이미지의 URL 가져오기
+		let downloadURL = try await imageRef.downloadURL()
+		
+		return (index, downloadURL)
+	}
+}
+
+// MARK: - Firestore Post Upload & Drink Update
+extension ExRecordViewModel {
+    // Firestore post data upload
+    func uploadPost() async {
+		guard let post = post, let userID = post.userField.userID else {
+			print("uploadPost() :: error -> don't get post & post's userID")
+			return
+		}
+        // posts documentID uuid 지정
+        let postDocumentPath = UUID().uuidString
+        let postRef = db.collection("posts")
+		let userPostRef = db.collection("users").document(userID).collection("posts")
+//		await firebaseUploadPost(ref: userPostRef, documentPath: postDocumentPath)
+        let references: [CollectionReference] = [postRef, userPostRef]
+        
+        // 동일한 post collection data를 갖는 collection(posts, users/posts)에 data upload
+        for reference in references {
+            await firebaseUploadPost(ref: reference, documentPath: postDocumentPath)
+        }
+        
+        // 동일한 drink collection data를 갖는 collection(posts/drinkTags/drink, drinks)에 data update
+		await updateDrinkDataWithTag(documentPath: postDocumentPath, userID: userID)
+    }
+    
+    // Firestore posts collection upload
+    func firebaseUploadPost(ref: CollectionReference, documentPath: String) async {
+        guard let post = post else { return }
+        do {
+            // posts collection field data upload
+            try ref.document(documentPath).setData(from: post.postField)
+            // drinkTags collection data upload in posts collection
+			for drinkTag in drinkTags {
+				guard let drinkID = drinkTag.drink.drinkID else {
+					print("firebaseUploadPost() :: error -> don't get drinkID")
+					continue
+				}
+				try await ref.document(documentPath).collection("drinkTags").document(drinkID).setData(["rating": drinkTag.rating])
+				try ref.document(documentPath).collection("drinkTags").document(drinkID).collection("drink").document(drinkID).setData(from: drinkTag.drink)
+			}
+            
+            // user collection data upload in posts collection
+            try ref.document(documentPath)
+                .collection("user")
+				.document(post.userField.userID ?? "")
+                .setData(from: post.userField)
+            
+        } catch {
+            print("error :: post upload fail")
+        }
+    }
+    
+    // claculate rating data when user upload post with drinkTag
+    func calcDrinkRating(prev: Double, new: Double, count: Int) -> Double {
+        return (prev * Double(count) + new) / (Double(count) + 1)
+    }
+    
+    // Firestore drink collection update
+	func updateDrinkDataWithTag(documentPath: String, userID: String) async {
+        // drinks
+        let drinkRef = db.collection("drinks")
+        // posts/drinkTags/drink
+        let drinkTagRef = db.collection("posts").document(documentPath).collection("drinkTags")
+		// users/posts/drinkTags/drink
+		let userPostDrinkTagRef = db.collection("users").document(userID).collection("posts").document(documentPath).collection("drinkTags")
+        
+        do {
+            for drinkTag in drinkTags {
+				guard let post = post, let drinkID = drinkTag.drink.drinkID else { return }
+				var updateData: [String: Any] = [:]
+				// drink 정보를 바탕으로 update
+				let drinkData = try await drinkRef.document(drinkID).getDocument(as: FBDrink.self)
+				// rating이 4보다 큰 경우
+				// agePreference, genderPreference
+				if drinkTag.rating >= 4 {
+					let userAge: Int = post.userField.age / 10 * 10
+					let stringUserAge = String(userAge < 20 ? 20 : userAge)
+					let userGender = post.userField.gender
+					// agePreference + 1
+					var agePreference = drinkData.agePreference
+					agePreference[stringUserAge] = (agePreference[stringUserAge] ?? 0) + 1
+					// genderPreference + 1
+					var genderPreference = drinkData.genderPreference
+					genderPreference[userGender] = (genderPreference[userGender] ?? 0) + 1
+
+					updateData["agePreference"] = agePreference
+					updateData["genderPreference"] = genderPreference
+				}
+				// rating
+				let prev = drinkData.rating
+				let new = drinkTag.rating
+				let count = drinkData.taggedPostID.count
+				let rating = calcDrinkRating(prev: prev, new: new, count: count)
+				
+				// taggedPostID
+				var taggedPostID = drinkData.taggedPostID
+				taggedPostID.append(documentPath)
+				
+				updateData["rating"] = rating
+				updateData["taggedPostID"] = taggedPostID
+				
+				// drink data(agePreference, genderPreference, rating, taggedPostId) update in drinks, posts collection(posts/drinkTags)
+				try await drinkRef.document(drinkID).updateData(updateData)
+				try await drinkTagRef.document(drinkID).collection("drink").document(drinkID).updateData(updateData)
+				try await userPostDrinkTagRef.document(drinkID).collection("drink").document(drinkID).updateData(updateData)
+            }
+        } catch {
+            print("update error")
+        }
+    }
+	
+	func recordPostDataClear() {
+		self.post = nil
+		self.selectedDrinkTag = nil
+		self.drinkTags = []
+		self.images = []
+		self.imagesURL = []
+		self.content = ""
+		self.foodTags = []
+	}
+}
+
+// MARK: Post Modify
+extension ExRecordViewModel {
+	
+}

--- a/JUDA/ViewModel/Record/RecordViewModel.swift
+++ b/JUDA/ViewModel/Record/RecordViewModel.swift
@@ -71,11 +71,11 @@ final class RecordViewModel {
                 imagesURL = downloadURLs.sorted(by: { $0.0 < $1.0 }).map { $0.1 }
             }
         } catch FireStorageError.uploadImage {
-            
+            print("error :: uploadImageToStorage() -> upload Image data to FireStorage failure")
         } catch FireStorageError.fetchImageURL {
-            
+            print("error :: fetchImageURL() -> get Image URL from FireStorage failure")
         } catch {
-            
+            print("error :: uploadMultipleImagesToFirebaseStorageAsync() -> upload Multiple Images failure")
         }
     }
     
@@ -85,9 +85,9 @@ final class RecordViewModel {
         do {
             try await firestorePostService.uploadPostDocument(post: post, postID: postID)
         } catch PostError.upload {
-            // TODO: error 처리
+            print("error :: uploadPostDocument() -> upload post to Firestore failure")
         } catch {
-            // TODO: error 처리
+            print("error :: uploadPost() -> upload post failure")
         }
     }
     
@@ -126,9 +126,9 @@ final class RecordViewModel {
                 let result = await firestoreDrinkService.updateDrinkField(ref: drinkRef, drinkID: drinkID, data: ["rating": rating])
             }
         } catch DrinkError.fetchDrinkDocument {
-            // TODO: error 처리
+            print("error :: updateDrinkField() -> update drink data to Firestore failure")
         } catch {
-            // TODO: error 처리
+            print("error :: updateDrink() -> update drink data failure")
         }
     }
     

--- a/JUDA/ViewModel/Record/RecordViewModel.swift
+++ b/JUDA/ViewModel/Record/RecordViewModel.swift
@@ -26,7 +26,7 @@ final class RecordViewModel: ObservableObject {
     // 음식 태그를 담는 배열
     @Published var foodTags = [String]()
     // 글 작성 or 수정 기준 충족 ( 글 내용 필수 )
-    @Published var isPostContent: Bool = false
+    @Published var postContentIsEmpty: Bool = true
     // post 업로드 완료 확인 및 로딩 뷰 출력용 프로퍼티
     @Published var isPostUploading: Bool = false
     // 화면 너비 받아오기
@@ -48,9 +48,9 @@ final class RecordViewModel: ObservableObject {
     private let db = Firestore.firestore()
 
     // MARK: - 글 내용 유무 체크
-    func isPostContentNotEmpty() {
+    func checkPostContentIsEmpty() {
         let trimmedString = content.trimmingCharacters(in: .whitespacesAndNewlines) // 공백 + 개행문자 제외
-        isPostContent = !trimmedString.isEmpty
+        postContentIsEmpty = trimmedString.isEmpty
     }
 
     // MARK: - 게시글 작성


### PR DESCRIPTION
## 개요 (이슈 번호 및 요약)
- #142 
    - RecordViewModel 리팩토링
- #152 
    - RecordViewModel 관련 View 코드 수정

## 변경 사항 (작업 내용)
- ### Drink 모델 오타 수정
    - GenderPreference -> genderPreference
    - DrinkField 모델 drinkImageURL 옵셔널 타입 변경
- ### WrittenUser 모델 변경
    - userAge, userGender 추가
- ### 기존 RecordViewModel -> ExRecordViewModel 변경
- ### RecordViewModel 파일에 코드 새로 작성
    - uploadMultipleImagesToFirebaseStorageAsync() 수정
    - 기존 updateDrinkDataWithTag() -> updateDrinkToFirestore() 수정
    - 기존 uploadPost() -> uploadPostToFirestroe() 수정
    - 기존 updatePost() -> updatePostToFirestore() 수정 
- ### FireStorageService 내 uploadImageToStorage() 코드 수정
     ```swift
     // user profile image 업로드 시, 경로 userImages/fileName
     // post images 업로드 시, 경로 postsImages/userID/postID/fileName
     func uploadImageToStorage(folder: FireStorageFolderType, userID: String? = nil, postID: String? = nil, image: UIImage, fileName: String) async throws {
        do {
            var storagePath = folder.rawValue
            if let userID = userID, let postID = postID {
                storagePath += "/\(userID)/\(postID)"
            }
            let storageRoute = storageRef.child("\(storagePath)/\(fileName)")
            let data = Formatter.compressImage(image)
            let metaData = StorageMetadata()
            metaData.contentType = imageType
            guard let data = data else { return }
            let _ = try await storageRoute.putDataAsync(data, metadata: metaData)
        } catch {
            throw FireStorageError.uploadImage
        }
    }
    ```
- ### FirestorePostService 수정
    - FireStorage에 post images를 올릴 때, 폴더링을 위해 postID가 필요함
    - 기존 uploadPostDocument에서 uuid를 부여하는 코드를 제거하고, RecordViewModel에서 postID를 가지고 있도록 수정
    ```swift
    func uploadPostDocument(post: Post, postID: String) async throws {
        ...
    }
    ``` 
- ### RecordViewModel 관련 View 코드 수정
   - AddTagView
   - DrinkTagScroll
   - PhotoSelectPagingTab
   - SearchTagView
   - RecordView
       - 함수 RecordViewModel 이동
       - recordType에 따른 분기 처리
   - SelectedPhotoHorizontalScroll
       - recordType에 따른 분기 처리
           - add인 경우: 기존 코드
           - eidt인 경우: 
           ```swift
           if let post = recordViewModel.post {
               // post가 가진 ImagesURL을 KFImage로 보여주기
               ForEach(0..<(post.postField.imagesURL.count), id: \.self) { index in
                   SelectedImageKFImage(url: post.postField.imagesURL[index])
               }
           }
           ```
- ### Review comment 내용 반영
    - RecordViewModel 내 변수명 변경 및 다른 View 적용

## 스크린샷

## 특이사항 (트러블 슈팅 과정 및 참고 자료 등)

editPost 메소드 위치에 대해
- PostViewModel -> RecordViewModel 이동은 어떨까요..?
- 글 수정 시 RecordView를 재사용하여 수정작업이 이루어지기 때문에 RecordViewModel이 더 적합하지 않을까 하는 생각이 듭니다.