### PR TITLE
[Edit] ViewModel 변경에 따른 LikedView 및 관련 View 코드 수정 #152

### DIFF
--- a/JUDA/View/DrinkInfo/DrinkDetail/TaggedTrendingPosts.swift
+++ b/JUDA/View/DrinkInfo/DrinkDetail/TaggedTrendingPosts.swift
@@ -28,8 +28,7 @@ struct TaggedTrendingPosts: View {
                     NavigationLink(value: Route
                         .PostDetail(postUserType: post.postField.user.userID == authViewModel.currentUser?.userField.userID ? .writter : .reader,
                                     post: post,
-                                    usedTo: .drinkDetail,
-                                    postPhotosURL: post.postField.imagesURL)) {
+                                    usedTo: .drinkDetail)) {
                         if !isLoading {
                             if let user = authViewModel.currentUser {
                                 PostListCell(post: post,

--- a/JUDA/View/Liked/LikedDrinkList.swift
+++ b/JUDA/View/Liked/LikedDrinkList.swift
@@ -12,7 +12,7 @@ struct LikedDrinkList: View {
     @EnvironmentObject private var authViewModel: AuthViewModel
 
     var body: some View {
-        if let user = authService.currentUser,
+        if let user = authViewModel.currentUser,
            !user.likedDrinks.isEmpty {
             // MARK: iOS 16.4 이상
             if #available(iOS 16.4, *) {
@@ -40,24 +40,20 @@ struct LikedDrinkList: View {
 
 // MARK: - 스크롤 뷰 or 뷰 로 보여질 술찜 리스트
 struct LikedDrinkListContent: View {
-    @EnvironmentObject private var authService: AuthService
-    @EnvironmentObject private var likedViewModel: LikedViewModel
+    @EnvironmentObject private var authViewModel: AuthViewModel
     
     var body: some View {
-        LazyVStack {
-            if !likedViewModel.isLoading {
-                ForEach(likedViewModel.likedDrinks, id: \.drinkID) { drink in
+        if let user = authViewModel.currentUser, 
+            !user.likedDrinks.isEmpty {
+            LazyVStack {
+                ForEach(user.likedDrinks, id: \.drinkField.drinkID) { drink in
                     NavigationLink(value: Route
                         .DrinkDetailWithUsedTo(drink: drink,
                                                usedTo: .liked)) {
                         DrinkListCell(drink: drink,
                                       usedTo: .liked)
                     }
-                    .buttonStyle(EmptyActionStyle())
-                }
-            } else {
-                ForEach(0..<4) { _ in
-                    ShimmerDrinkListCell()
+                                               .buttonStyle(EmptyActionStyle())
                 }
             }
         }

--- a/JUDA/View/Liked/LikedPostGrid.swift
+++ b/JUDA/View/Liked/LikedPostGrid.swift
@@ -12,7 +12,7 @@ struct LikedPostGrid: View {
     @EnvironmentObject private var authViewModel: AuthViewModel
 
     var body: some View {
-        if let user = authService.currentUser,
+        if let user = authViewModel.currentUser,
            !user.likedPosts.isEmpty {
             // MARK: iOS 16.4 이상
             if #available(iOS 16.4, *) {
@@ -46,25 +46,21 @@ struct LikedPostGridContent: View {
     private let columns: [GridItem] = [GridItem(.flexible()), GridItem(.flexible())]
     
     var body: some View {
-        LazyVGrid(columns: columns, spacing: 10) {
-            if !likedViewModel.isLoading {
-                ForEach(likedViewModel.likedPosts, id: \.postField.postID) { post in
+        if let user = authViewModel.currentUser, 
+            !user.likedPosts.isEmpty {
+            LazyVGrid(columns: columns, spacing: 10) {
+                ForEach(user.likedPosts, id: \.postField.postID) { post in
                     NavigationLink(value: Route
-                        .PostDetail(postUserType: authService.currentUser?.userID == post.userField.userID ? .writter : .reader,
+                        .PostDetail(postUserType: user.userField.userID == post.postField.user.userID ? .writter : .reader,
                                     post: post,
-                                    usedTo: .liked,
-                                    postPhotosURL: post.postField.imagesURL)) {
+                                    usedTo: .liked)) {
                         PostCell(usedTo: .liked, post: post)
                     }
-                    .buttonStyle(EmptyActionStyle())
-                }
-            } else {
-                ForEach(0..<6) { _ in
-                    ShimmerPostCell()
+                                    .buttonStyle(EmptyActionStyle())
                 }
             }
+            .padding(.horizontal, 20)
         }
-        .padding(.horizontal, 20)
     }
 }
 

--- a/JUDA/View/Liked/LikedView.swift
+++ b/JUDA/View/Liked/LikedView.swift
@@ -39,21 +39,9 @@ struct LikedView: View {
                                 if LikedType.list[index] == .drink {
                                     // 술찜 리스트
                                     LikedDrinkList()
-                                        .task {
-                                            if likedViewModel.likedDrinks.isEmpty {
-                                                await likedViewModel
-                                                    .getLikedDrinks(likedDrinksIDList: authService.currentUser?.likedDrinks)
-                                            }
-                                        }
                                 } else {
                                     // 술상 리스트
                                     LikedPostGrid()
-                                        .task {
-                                            if likedViewModel.likedPosts.isEmpty {
-                                                await likedViewModel
-                                                    .getLikedPosts(likedPostsIDList: authService.currentUser?.likedPosts)
-                                            }
-                                        }
                                 }
                             }
                             .onChange(of: selectedSegmentIndex) { newValue in
@@ -99,19 +87,6 @@ struct LikedView: View {
                 default:
                     ErrorPageView()
                         .modifier(TabBarHidden())
-                }
-            }
-            .onChange(of: selectedSegmentIndex) { newValue in
-                Task {
-                    // 술 -> 술상
-                    if newValue == 1 {
-                        await likedViewModel
-                            .getLikedDrinks(likedDrinksIDList: authService.currentUser?.likedDrinks)
-                        // 술상 -> 술
-                    } else {
-                        await likedViewModel
-                            .getLikedPosts(likedPostsIDList: authService.currentUser?.likedPosts)
-                    }
                 }
             }
             .onAppear {

--- a/JUDA/View/Main/PostTopView.swift
+++ b/JUDA/View/Main/PostTopView.swift
@@ -34,8 +34,7 @@ struct PostTopView: View {
                 NavigationLink(value: Route
                     .PostDetail(postUserType: authViewModel.currentUser?.userField.userID == post.postField.user.userID ? .writter : .reader,
                                 post: post,
-                                usedTo: .main,
-                                postPhotosURL: post.postField.imagesURL)) {
+                                usedTo: .main)) {
                     if let user = authViewModel.currentUser {
                         PostListCell(post: post,
                                      isLiked: post.likedUsersID.contains(user.userField.userID ?? ""))

--- a/JUDA/View/Posts/PostGrid.swift
+++ b/JUDA/View/Posts/PostGrid.swift
@@ -85,8 +85,7 @@ struct PostGridContent: View {
                         NavigationLink(value: Route
                             .PostDetail(postUserType: authViewModel.currentUser?.userField.userID == post.postField.user.userID ? .writter : .reader,
                                         post: post,
-                                        usedTo: usedTo,
-                                        postPhotosURL: post.postField.imagesURL)) {
+                                        usedTo: usedTo)) {
                             PostCell(usedTo: .post, post: post)
                                 .task {
                                     if post == postViewModel.posts.last {
@@ -111,8 +110,7 @@ struct PostGridContent: View {
 							NavigationLink(value: Route
                                 .PostDetail(postUserType: authViewModel.currentUser?.userField.userID == post.postField.user.userID ? .writter : .reader,
                                             post: post,
-                                            usedTo: usedTo,
-                                            postPhotosURL: post.postField.imagesURL)) {
+                                            usedTo: usedTo)) {
 								PostCell(usedTo: .postSearch, post: post)
 							}
 							.buttonStyle(EmptyActionStyle())
@@ -124,8 +122,7 @@ struct PostGridContent: View {
 							NavigationLink(value: Route
                                 .PostDetail(postUserType: authViewModel.currentUser?.userField.userID == post.postField.user.userID ? .writter : .reader,
                                             post: post,
-                                            usedTo: usedTo,
-                                            postPhotosURL: post.postField.imagesURL)) {
+                                            usedTo: usedTo)) {
 								PostCell(usedTo: .postSearch, post: post)
 							}
 							.buttonStyle(EmptyActionStyle())
@@ -137,8 +134,7 @@ struct PostGridContent: View {
 							NavigationLink(value: Route
                                 .PostDetail(postUserType: authViewModel.currentUser?.userField.userID == post.postField.user.userID ? .writter : .reader,
                                             post: post,
-                                            usedTo: usedTo,
-                                            postPhotosURL: post.postField.imagesURL)) {
+                                            usedTo: usedTo)) {
 								PostCell(usedTo: .postSearch, post: post)
 							}
 							.buttonStyle(EmptyActionStyle())
@@ -152,8 +148,7 @@ struct PostGridContent: View {
 					NavigationLink(value: Route
                         .PostDetail(postUserType: authViewModel.currentUser?.userField.userID == post.postField.user.userID ? .writter : .reader,
                                     post: post,
-                                    usedTo: usedTo,
-                                    postPhotosURL: post.postField.imagesURL)) {
+                                    usedTo: usedTo)) {
 						PostCell(usedTo: .postSearch, post: post)
 					}
 					.buttonStyle(EmptyActionStyle())
@@ -166,8 +161,7 @@ struct PostGridContent: View {
                         NavigationLink(value: Route
                             .PostDetail(postUserType: authViewModel.currentUser?.userField.userID == post.postField.user.userID ? .writter : .reader,
                                         post: post,
-                                        usedTo: usedTo,
-                                        postPhotosURL: post.postField.imagesURL)) {
+                                        usedTo: usedTo)) {
 							PostCell(usedTo: usedTo, post: post)
                         }
                     }
@@ -179,23 +173,25 @@ struct PostGridContent: View {
             } else if usedTo == .myPage {
                 if !userViewModel.isLoading {
                     if userType == .user {
-                        ForEach(authViewModel.currentUser?.posts, id: \.postField.postID) { post in
-                            NavigationLink(value: Route
-                                .PostDetail(postUserType: .writter,
-                                            post: post,
-                                            usedTo: usedTo,
-                                            postPhotosURL: post.postField.imagesURL)) {
-                                PostCell(usedTo: usedTo, post: post)
+                        if let currentUser = authViewModel.currentUser, !currentUser.posts.isEmpty {
+                            ForEach(currentUser.posts, id: \.postField.postID) { post in
+                                NavigationLink(value: Route
+                                    .PostDetail(postUserType: .writter,
+                                                post: post,
+                                                usedTo: usedTo)) {
+                                    PostCell(usedTo: usedTo, post: post)
+                                }
                             }
                         }
                     } else {
-                        ForEach(userViewModel.user?.posts, id: \.postField.postID) { post in
-                            NavigationLink(value: Route
-                                .PostDetail(postUserType: .reader,
-                                            post: post,
-                                            usedTo: usedTo,
-                                            postPhotosURL: post.postField.imagesURL)) {
-                                PostCell(usedTo: usedTo, post: post)
+                        if let user = userViewModel.user, !user.posts.isEmpty {
+                            ForEach(user.posts, id: \.postField.postID) { post in
+                                NavigationLink(value: Route
+                                    .PostDetail(postUserType: .reader,
+                                                post: post,
+                                                usedTo: usedTo)) {
+                                    PostCell(usedTo: usedTo, post: post)
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
## 개요 (이슈 번호 및 요약)
- #152 
    - LikedView,  LikedDrinkList, LikedPostGrid 코드 수정
- 일부 코드 수정
## 변경 사항 (작업 내용)
- ### LikedView, LikedDrinkList, LikedPostGrid 코드 수정
    - 데이터 구조의 변경 작업에 따라 LikeViewModel을 사용하지 않고 authViewModel 사용
         [likedPosts, likedDrinks 데이터 구조: (기존) postID, drinkID로 가짐 -> (변경) Post와 Drink의 전체 정보를 담고 있음]
         [authViewModel의 currentUser fetch 시, likedPosts와 likedDrinks의 또한 fetch]

    - authViewModel의 currentUser fetch 시, likedPosts와 likedDrinks가 fetch 되기 때문에, 
       기존 task에서 fetch 해주는 코드 삭제
       기존 LikedDrinkList와 LikedPostGrid 사용하던 shimmer 삭제

    - 기존에 사용하던 LikedViewModel는 삭제 (예정)

- ### 일부 코드 수정
    - Route의 PostDetail의 연관값 변경에 따른 사용처 코드 수정
    
## 스크린샷

## 특이사항 (트러블 슈팅 과정 및 참고 자료 등)
