### PR TITLE
[Edit] MyPage 관련 View 코드 수정 #152

### DIFF
--- a/JUDA/Model/User.swift
+++ b/JUDA/Model/User.swift
@@ -28,9 +28,14 @@ struct UserField: Codable {
     var authProviders: String // AuthProviderOption - rawValue
 }
 
-struct UserNotification {
+struct UserNotification: Equatable {
+    @DocumentID var userNotificationID: String?
     var notificationField: NotificationField
     var likedPost: Post
+    
+    static func == (lhs: UserNotification, rhs: UserNotification) -> Bool {
+        lhs.userNotificationID == rhs.userNotificationID
+    }
 }
 
 // Firebase users/notificationList 컬렉션 데이터 모델

--- a/JUDA/View/DrinkInfo/DrinkInfoView.swift
+++ b/JUDA/View/DrinkInfo/DrinkInfoView.swift
@@ -200,11 +200,9 @@ struct DrinkInfoView: View {
                     NavigationPostsView(usedTo: usedTo,
                                         searchTagType: searchTagType,
                                         postSearchText: postSearchText)
-                case .NavigationProfile(let postUserName,
-                                        let postUserID,
-                                        let usedTo):
-                    NavigationProfileView(postUserName: postUserName,
-                                          postUserID: postUserID,
+                case .NavigationProfile(let userID,
+                                      let usedTo):
+                    NavigationProfileView(userID: userID,
                                           usedTo: usedTo)
                 case .Record(let recordType):
                     RecordView(recordType: recordType)

--- a/JUDA/View/Liked/LikedView.swift
+++ b/JUDA/View/Liked/LikedView.swift
@@ -69,11 +69,9 @@ struct LikedView: View {
                 case .AddTag:
                     AddTagView()
                         .modifier(TabBarHidden())
-                case .NavigationProfile(let postUserName,
-                                      let postUserID,
+                case .NavigationProfile(let userID,
                                       let usedTo):
-                    NavigationProfileView(postUserName: postUserName,
-                                          postUserID: postUserID,
+                    NavigationProfileView(userID: userID,
                                           usedTo: usedTo)
                 case .Record(let recordType):
                     RecordView(recordType: recordType)

--- a/JUDA/View/Main/MainView.swift
+++ b/JUDA/View/Main/MainView.swift
@@ -53,11 +53,9 @@ struct MainView: View {
                     NavigationPostsView(usedTo: usedTo,
                                         searchTagType: searchTagType,
                                         postSearchText: postSearchText)
-                case .NavigationProfile(let postUserName,
-                                        let postUserID,
-                                        let usedTo):
-                    NavigationProfileView(postUserName: postUserName,
-                                          postUserID: postUserID,
+                case .NavigationProfile(let userID,
+                                      let usedTo):
+                    NavigationProfileView(userID: userID,
                                           usedTo: usedTo)
                 case .Record(let recordType):
                     RecordView(recordType: recordType)

--- a/JUDA/View/Mypage/AuthenticatedMypageView.swift
+++ b/JUDA/View/Mypage/AuthenticatedMypageView.swift
@@ -11,16 +11,12 @@ import FirebaseAuth
 // MARK: - 마이페이지 탭
 struct AuthenticatedMypageView: View {
     @EnvironmentObject private var appViewModel: AppViewModel
-    @EnvironmentObject private var authService: AuthService
-    @EnvironmentObject private var myPageViewModel: MyPageViewModel
-
+    @EnvironmentObject private var authViewModel: AuthViewModel
+    
     var body: some View {
         VStack {
             // 프로필 사진 -- 닉네임 -- 수정
-            UserProfileView(userType: UserType.user,
-                            userName: authService.currentUser?.name ?? "",
-                            userID: authService.currentUser?.userID ?? "",
-                            usedTo: .myPage)
+            UserProfileView(userType: .user)
             // 내가 작성한 게시물 -- '새 글 작성하기'
             HStack {
                 Text("내가 작성한 술상")
@@ -52,13 +48,6 @@ struct AuthenticatedMypageView: View {
                 }
             }
         }
-        // 작성한 술상 데이터 가져오기
-        .task {
-            if myPageViewModel.userPosts.isEmpty {
-                await myPageViewModel.getUsersPosts(userID: authService.currentUser?.userID ?? "",
-                                                    userType: .user)
-            }
-        }
         .toolbar {
             ToolbarItem(placement: .topBarLeading) {
                 Text("마이페이지")
@@ -81,7 +70,7 @@ struct AuthenticatedMypageView: View {
         .onAppear {
             appViewModel.tabBarState = .visible
             Task {
-                await authService.startListeningForUser()
+                await authViewModel.startListeningForUserField()
             }
         }
         .toolbar(appViewModel.tabBarState, for: .tabBar)

--- a/JUDA/View/Mypage/MyPageView.swift
+++ b/JUDA/View/Mypage/MyPageView.swift
@@ -9,12 +9,12 @@ import SwiftUI
 
 struct MyPageView: View {
     @StateObject private var navigationRouter = NavigationRouter()
-    @EnvironmentObject private var authService: AuthService
+    @EnvironmentObject private var authViewModel: AuthViewModel
 
     var body: some View {
         NavigationStack(path: $navigationRouter.path) {
             VStack {
-                if authService.signInStatus {
+                if authViewModel.signInStatus {
                     AuthenticatedMypageView()
                 } else {
                     UnauthenticatedMypageView()
@@ -39,11 +39,9 @@ struct MyPageView: View {
                         .modifier(TabBarHidden())
                 case .Notice:
                     NoticeView()
-                case .NavigationProfile(let postUserName,
-                                      let postUserID,
+                case .NavigationProfile(let userID,
                                       let usedTo):
-                    NavigationProfileView(postUserName: postUserName,
-                                          postUserID: postUserID,
+                    NavigationProfileView(userID: userID,
                                           usedTo: usedTo)
                 case .Record(let recordType):
                     RecordView(recordType: recordType)

--- a/JUDA/View/Mypage/MypageDetail/AlarmStoreListCell.swift
+++ b/JUDA/View/Mypage/MypageDetail/AlarmStoreListCell.swift
@@ -10,15 +10,15 @@ import Kingfisher
 
 // MARK: - 알람 리스트 셀
 struct AlarmStoreListCell: View {
-    @EnvironmentObject private var notificationViewModel: MyPageViewModel
-    let alarm: NotificationField
+    @EnvironmentObject private var authViewModel: AuthViewModel
+    let alarm: UserNotification
     
     var body: some View {
         HStack(alignment: .center) {
             VStack(alignment: .leading, spacing: 2) {
                 // 게사물 좋아요 알람 내용
                 Group {
-                    Text(alarm.likedUserName)
+                    Text(alarm.notificationField.likedUser.userName)
                         .font(.medium14)
                     +
                     Text(" 님이 게시물에 하트를 남겼어요.")
@@ -27,21 +27,22 @@ struct AlarmStoreListCell: View {
                 .multilineTextAlignment(.leading)
                 .foregroundStyle(.mainBlack)
                 .overlay(alignment: .topLeading) {
+                    // TODO: userName 클릭 시, NavigationProfileView로 이동
 //                    NavigationLink(value: Route.NavigationProfile) {
-                        Text(alarm.likedUserName)
+                        Text(alarm.notificationField.likedUser.userName)
                             .font(.medium14)
                             .foregroundStyle(.mainBlack)
 //                    }
 //                    .buttonStyle(EmptyActionStyle())
                 }
                 // 알람 왔던 시기
-                Text(Formatter.formattedDateBeforeStyle(pastDate: alarm.likedTime))
+                Text(Formatter.formattedDateBeforeStyle(pastDate: alarm.notificationField.likedTime))
                     .font(.regular12)
                     .foregroundStyle(.gray01)
             }
             Spacer()
             // 해당 술상 이미지
-            if let imageURL = alarm.thumbnailImageURL {
+            if let imageURL = alarm.notificationField.thumbnailImageURL {
                 KFImage.url(imageURL)
                     .placeholder {
                         CircularLoaderView(size: 20)

--- a/JUDA/View/Mypage/MypageDetail/AlarmStoreView.swift
+++ b/JUDA/View/Mypage/MypageDetail/AlarmStoreView.swift
@@ -11,8 +11,6 @@ import FirebaseAuth
 // MARK: - 알람 쌓여있는 리스트 화면
 struct AlarmStoreView: View {
     @EnvironmentObject private var navigationRouter: NavigationRouter
-    @EnvironmentObject private var notificationViewModel: MyPageViewModel
-	@EnvironmentObject private var authService: AuthService
 
     var body: some View {
         VStack(spacing: 0) {
@@ -50,27 +48,31 @@ struct AlarmStoreView: View {
                     .foregroundStyle(.mainBlack)
             }
         }
-        .task {
-            await notificationViewModel.fetchNotificationList(userId: authService.currentUser?.userID ?? "")
-        }
+        // TODO: notification refetch는 어디서 이루어지는가
+//        .task {
+//            await notificationViewModel.fetchNotificationList(userId: authService.currentUser?.userID ?? "")
+//        }
     }
 }
 
 // MARK: - 스크롤 뷰 or 뷰 로 보여질 알람 리스트
 struct AlarmListContent: View {
-    @EnvironmentObject private var notificationViewModel: MyPageViewModel
+    @EnvironmentObject private var authViewModel: AuthViewModel
 
     var body: some View {
-        LazyVStack {
-            ForEach(notificationViewModel.notifications.indices, id: \.self) { index in
-                let alarm = notificationViewModel.notifications[index]
-                
-//                NavigationLink(value: post) {
-//                    AlarmStoreListCell(alarm: alarm)
-//                }
-                AlarmStoreListCell(alarm: alarm)
-                if alarm != notificationViewModel.notifications.last {
-                    CustomDivider()
+        if let user = authViewModel.currentUser {
+            LazyVStack {
+                ForEach(user.notifications.indices, id: \.self) { index in
+                    let alarm = user.notifications[index]
+                    // TODO: AlarmStoreListCell 클릭 시 해당 postDetailView로 이동
+//                    NavigationLink(value: post) {
+//                        AlarmStoreListCell(alarm: alarm)
+//                    }
+                    AlarmStoreListCell(alarm: alarm)
+                    
+                    if alarm != user.notifications.last {
+                        CustomDivider()
+                    }
                 }
             }
         }

--- a/JUDA/View/Mypage/MypageDetail/UserProfileView.swift
+++ b/JUDA/View/Mypage/MypageDetail/UserProfileView.swift
@@ -40,28 +40,9 @@ struct UserProfileView: View {
             HStack {
                 HStack(spacing: 20) {
                     HStack(alignment: .bottom, spacing: -15) {
-                        // MARK: - KFImage의 placeholder의 역할에 따라, userType 분기를 두어야 할 거 같음
                         // 사용자 프로필 이미지
-//                        if userType == .user { // 사용자 지정 이미지가 있을 때 (이미지 선택 완료했을 경우)
-//                            KFImage.url(profileImageURL)
-//                                .placeholder {
-//                                    Image(uiImage: selectedImage)
-//                                        .resizable()
-//                                        .aspectRatio(contentMode: .fill)
-//                                        .clipShape(Circle())
-//                                        .frame(width: 70, height: 70)
-//                                }
-//                                .loadDiskFileSynchronously(true) // 디스크에서 동기적으로 이미지 가져오기
-//                                .cancelOnDisappear(true) // 화면 이동 시, 진행중인 다운로드 중단
-//                                .cacheMemoryOnly() // 메모리 캐시만 사용 (디스크 X)
-//                                .fade(duration: 0.2) // 이미지 부드럽게 띄우기
-//                                .resizable()
-//                                .aspectRatio(contentMode: .fill)
-//                                .clipShape(Circle())
-//                                .frame(width: 70, height: 70)
-//                        } else if let profileImageURL = profileImageURL {
                         if let profileImageURL = profileImageURL {
-                            UserProfileKFImage(url: profileImageURL)
+                            UserProfileKFImage(url: profileImageURL, userType: userType, selectedImage: selectedImage)
                         } else {
                             // 사용자 지정 이미지가 없을 때 기본 이미지로 설정
                             Image("defaultprofileimage")
@@ -134,9 +115,20 @@ struct UserProfileView: View {
 // MARK: - UserProfileView 의 이미지 프로필에서 사용하는 KFImage
 struct UserProfileKFImage: View {
     let url: URL
+    let userType: UserType
+    let selectedImage: UIImage
     
     var body: some View {
         KFImage.url(url)
+            .placeholder {
+                if userType == .user {
+                    Image(uiImage: selectedImage)
+                        .resizable()
+                        .aspectRatio(contentMode: .fill)
+                        .clipShape(Circle())
+                        .frame(width: 70, height: 70)
+                }
+            }
             .loadDiskFileSynchronously(true) // 디스크에서 동기적으로 이미지 가져오기
             .cancelOnDisappear(true) // 화면 이동 시, 진행중인 다운로드 중단
             .cacheMemoryOnly() // 메모리 캐시만 사용 (디스크 X)

--- a/JUDA/View/Mypage/NavigationProfileView.swift
+++ b/JUDA/View/Mypage/NavigationProfileView.swift
@@ -10,26 +10,23 @@ import SwiftUI
 // MARK: - 네비게이션 이동 시, 유저 프로필 화면
 struct NavigationProfileView: View {
     @EnvironmentObject private var navigationRouter: NavigationRouter
-    @EnvironmentObject private var authService: AuthService
-    @EnvironmentObject private var myPageViewModel: MyPageViewModel
+    @EnvironmentObject private var authViewModel: AuthViewModel
+    @EnvironmentObject private var userViewModel: UserViewModel
     
-    let postUserName: String
-    let postUserID: String
+    let userID: String
     let usedTo: WhereUsedPostGridContent
-    var userType: UserType {
-        postUserID == authService.currentUser?.userID ? .user : .otheruser
+    // 해당 게시글의 작성자가 로그인한 유저인지 판별
+    private var userType: UserType {
+        userID == authViewModel.currentUser?.userField.userID ? .user : .otherUser
     }
     
     var body: some View {
         VStack {
             // 프로필 사진 -- 닉네임 -- 수정
-            UserProfileView(userType: userType,
-                            userName: postUserName,
-                            userID: postUserID,
-                            usedTo: usedTo)
+            UserProfileView(userType: userType)
             // 내가 작성한 게시물 -- 술상 올리기
             HStack {
-                userType == .user ? Text("내가 작성한 술상") : Text("\(postUserName) 님이 작성한 술상")
+                userType == .user ? Text("내가 작성한 술상") : Text("\(userViewModel.user?.userField.name ?? "") 님이 작성한 술상")
                     .font(.semibold18)
                 Spacer()
                 
@@ -67,10 +64,11 @@ struct NavigationProfileView: View {
                 }
             }
         }
-        // 작성한 술상 데이터 가져오기
+        //
         .task {
-            await myPageViewModel.getUsersPosts(userID: userType == .user ? authService.currentUser?.userID ?? "" : postUserID,
-                                                userType: userType)
+            if userType == .otherUser {
+                await userViewModel.getUser(uid: userID)
+            }
         }
         .toolbar {
             ToolbarItem(placement: .topBarLeading) {
@@ -82,7 +80,7 @@ struct NavigationProfileView: View {
                 }
             }
             ToolbarItem(placement: .principal) {
-                userType == .user ? Text("마이페이지") : Text("\(postUserName) 님의 페이지")
+                userType == .user ? Text("마이페이지") : Text("\(userViewModel.user?.userField.name ?? "") 님의 페이지")
                     .font(.medium16)
             }
         }

--- a/JUDA/View/Mypage/UnauthenticatedMypageView.swift
+++ b/JUDA/View/Mypage/UnauthenticatedMypageView.swift
@@ -10,7 +10,6 @@ import SwiftUI
 // MARK: - 로그인 X 일 경우 보여지는 MypageView
 struct UnauthenticatedMypageView: View {
     @EnvironmentObject private var appViewModel: AppViewModel
-    @EnvironmentObject private var authService: AuthService
 
     var body: some View {
         VStack {

--- a/JUDA/View/Posts/PostDetail/PostInfo.swift
+++ b/JUDA/View/Posts/PostDetail/PostInfo.swift
@@ -37,8 +37,7 @@ struct PostInfo: View {
                 }
                 VStack(alignment: .leading) {
                     NavigationLink(value: Route
-                        .NavigationProfile(postUserName: post.postField.user.userName,
-                                           postUserID: post.postField.user.userID,
+                        .NavigationProfile(userID: post.postField.user.userID,
                                            usedTo: usedTo)) {
                         // 사용자의 닉네임
                         Text(post.postField.user.userName)

--- a/JUDA/View/Posts/PostsView.swift
+++ b/JUDA/View/Posts/PostsView.swift
@@ -149,11 +149,9 @@ struct PostsView: View {
                                         searchTagType: searchTagType,
                                         postSearchText: postSearchText)
                     .modifier(TabBarHidden())
-                case .NavigationProfile(let postUserName,
-                                        let postUserID,
-                                        let usedTo):
-                    NavigationProfileView(postUserName: postUserName,
-                                          postUserID: postUserID,
+                case .NavigationProfile(let userID,
+                                      let usedTo):
+                    NavigationProfileView(userID: userID,
                                           usedTo: usedTo)
                 case .Record(let recordType):
                     RecordView(recordType: recordType)

--- a/JUDA/ViewModel/App/NavigationRouter.swift
+++ b/JUDA/ViewModel/App/NavigationRouter.swift
@@ -16,8 +16,7 @@ enum Route: Hashable {
     case Notice
     case ChangeUserName
     case Record(recordType: RecordType)
-    case NavigationProfile(postUserName: String,
-                           postUserID: String,
+    case NavigationProfile(userID: String,
                            usedTo: WhereUsedPostGridContent)
     case NavigationPosts(usedTo: WhereUsedPostGridContent,
                          searchTagType: SearchTagType?,

--- a/JUDA/ViewModel/Drink/FirestoreDrinkService.swift
+++ b/JUDA/ViewModel/Drink/FirestoreDrinkService.swift
@@ -200,7 +200,7 @@ extension FirestoreDrinkService {
     // drink collection agePreference data update 메서드
     func updateDrinkAgePreference(ref: CollectionReference, drinkID: String, age: Age, userID: String) async {
         do {
-            try await ref.document(drinkID).collection("agePreference").document(age.rawValue).collection("usersID").document(userID).setData([:])
+            try await ref.document(drinkID).collection("agePreferenceUID").document(age.rawValue).collection("usersID").document(userID).setData([:])
         } catch {
             print("error :: updateDrinkAgePreference() -> upload userID to agePreference failure")
         }
@@ -209,7 +209,7 @@ extension FirestoreDrinkService {
     // drink collection genderPreference data update 메서드
     func updateDrinkGenderPreference(ref: CollectionReference, drinkID: String, gender: String, userID: String) async {
         do {
-            try await ref.document(drinkID).collection("genderPreference").document(gender).collection("usersID").document(userID).setData([:])
+            try await ref.document(drinkID).collection("genderPreferenceUID").document(gender).collection("usersID").document(userID).setData([:])
         } catch {
             print("error :: updateDrinkGenderPreference() -> upload userID to genderPreference failure")
         }


### PR DESCRIPTION
## 개요 (이슈 번호 및 요약)
- #152 
    - MyPage 관련 뷰 수정

## 변경 사항 (작업 내용)
- ### MyPage Group 하위 뷰 (Setting 제외) 코드 수정
    - 변경된 ViewModel를 사용하는 코드로 수정
- ### NavigationProfileView 수정으로 인하여 Route 코드 수정 및 사용처 코드 수정
    - 기존
    ```swift
    case .NavigationProfile(let postUserName,
                          let postUserID,
                          let usedTo):
        NavigationProfileView(postUserName: postUserName,
                              postUserID: postUserID,
                              usedTo: usedTo)
    ``` 
    - 변경
    ```swift
     case .NavigationProfile(let userID,
                          let usedTo):
         NavigationProfileView(userID: userID,
                              usedTo: usedTo)
    ```
- ### ChangeUserNameView 로직 수정
    - isCompleted로 기준 충족 여부를 판별하지 않고 있는 문제 발견 후, checkIsCompleted() 추가 및 기준 충족 여부 판별
    - 기존 닉네임과 동일한 경우에도 Text를 띄워주도록 변경

- ### UserNotification 데이터 모델에 DocumentID 추가
    - AlarmStoreView 내 User notifications의 마지막 요소인지 판별하는 과정에서 필요에 의해 추가
  
- ### UserProfileKFImage 코드 수정
    - userType가 .user인 경우, placeholder를 사용하기 때문에 UserProfileKFImage에서 분기처리를 하도록 수정

## 스크린샷

## 특이사항 (트러블 슈팅 과정 및 참고 자료 등)
---
## 이후 작업해야 할 사항
- ### authViewModel, userViewModel User Data 다시 패치
    - 재패치가 이루어져야 하는 부분이 모호한 것 같아서, 기존 재패치 하는 코드를 주석처리한 후, TODO로 처리해두었습니다.

- ### KingFisher 이미지 사용 부분 수정
    - UserProfileView 기존 코드에서 userType에 따라 KFImage에 placeholder 적용 여부가 달라지는데, 현재 유저인 경우 프로필 사진을 변경하는 과정에서 placeholder가 필요한 것으로 생각됩니다.
    - 추후 KFImage 작업을 하면서 이 부분도 체크해야 할 것 같습니다 -!

- ### AlarmStoreView, AlarmListCell의 Navigation 연결
    - 추후 머지 후 시뮬 돌리면서 작업하겠습니다. :)