### PR TITLE
[Edit] SettingView 알람 세팅 방식 수정 #152

### DIFF
--- a/JUDA/View/Mypage/SettingDetail/AppServiceInfoView.swift
+++ b/JUDA/View/Mypage/SettingDetail/AppServiceInfoView.swift
@@ -24,7 +24,10 @@ struct AppServiceInfoView: View {
                 Spacer()
                 Image(systemName: "chevron.forward")
             }
-            .modifier(CustomText())
+            .font(.regular16)
+            .foregroundStyle(.mainBlack)
+            .padding(.horizontal, 20)
+            .padding(.vertical, 10)
             .fullScreenCover(isPresented: $isShowWebView) {
                 SafariView(url: URL(string: self.urlString)!)
             }

--- a/JUDA/View/Mypage/SettingView.swift
+++ b/JUDA/View/Mypage/SettingView.swift
@@ -14,7 +14,6 @@ struct SettingView: View {
     @EnvironmentObject private var navigationRouter: NavigationRouter
     @EnvironmentObject private var authViewModel: AuthViewModel
     @EnvironmentObject private var appViewModel: AppViewModel
-    @EnvironmentObject private var userViewModel: UserViewModel
     @EnvironmentObject private var colorScheme: SystemColorTheme
     
     private let optionNameList = ["라이트 모드", "다크 모드", "시스템 모드"] // 화면 모드 설정 옵션 이름 리스트

--- a/JUDA/ViewModel/Auth/FirebaseAuthService.swift
+++ b/JUDA/ViewModel/Auth/FirebaseAuthService.swift
@@ -55,6 +55,16 @@ extension FirebaseAuthService {
             print("error :: updateUserName", error.localizedDescription)
         }
     }
+    
+    // firestore 에서 유저 알림 상태 설정 변경
+    func updateUserNotification(uid: String, notificationAllowed: Bool) async {
+        do {
+            let docRef = db.collection(userCollection).document(uid)
+            try await docRef.updateData(["notificationAllowed": notificationAllowed])
+        } catch {
+            print("error :: updateUserNotification", error.localizedDescription)
+        }
+    }
 }
 
 // MARK: - 데이터 실시간 업데이트


### PR DESCRIPTION
## 개요 (이슈 번호 및 요약)
- #152 

## 변경 사항 (작업 내용)
### SettingView 항목 중 알람 세팅 버튼에서 토글로 수정

- 토글 누르면, 아이폰의 `시스템 설정 / 알림 / 앱` 으로 이동
- 시스템 설정에서 설정 변경 한 상태를 토대로, 화면의 프로퍼티 State 와 파베의 유저 데이터 업데이트
- ( 추가 ) 기존 유저는 알림을 true 로 했지만, 앱에 들어오지 않고 시스템 설정에서 변경 했을 수 있으니, SettingView 를 .onAppear 할 때, 한번 시스템의 정보를 받아와서 변경되었다면 업데이트 해주도록 설정

## 스크린샷
### 예시용 화면 ( 테스트 용으로 만들었던 앱 영상 )
https://github.com/JUDA-Hrmi/JUDA/assets/109324421/9348cb28-7457-4a54-98f9-a19836ee4336

