### PR TITLE
[Refactoring] - 에러 수정

### DIFF
--- a/JUDA_iOS/JUDA.xcodeproj/project.pbxproj
+++ b/JUDA_iOS/JUDA.xcodeproj/project.pbxproj
@@ -20,6 +20,8 @@
 		093357CB2B954A8A00A9ACAB /* GoogleSignInSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 093357CA2B954A8A00A9ACAB /* GoogleSignInSwift */; };
 		093357CF2B95505E00A9ACAB /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 093357CE2B95505B00A9ACAB /* AppDelegate.swift */; };
 		094D07F82BA7C2F200904E73 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 094D07F72BA7C2F200904E73 /* Constants.swift */; };
+		09506F4C2BAC929A000557BE /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 09506F4A2BAC929A000557BE /* GoogleService-Info.plist */; };
+		09506F4D2BAC929A000557BE /* APIKEYS.plist in Resources */ = {isa = PBXBuildFile; fileRef = 09506F4B2BAC929A000557BE /* APIKEYS.plist */; };
 		095D708D2B98200B00F76C11 /* FirebaseUserService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 095D708C2B98200B00F76C11 /* FirebaseUserService.swift */; };
 		095D70912B99BD1400F76C11 /* UserViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 095D70902B99BD1400F76C11 /* UserViewModel.swift */; };
 		095D70932B99EAA500F76C11 /* MainViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 095D70922B99EAA500F76C11 /* MainViewModel.swift */; };
@@ -62,8 +64,6 @@
 		09BCC15F2B7CFC7E00FF4D1B /* TermsAndVerificationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09BCC15E2B7CFC7E00FF4D1B /* TermsAndVerificationView.swift */; };
 		09C7C9AF2B8DB57E00F62617 /* NavigationRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09C7C9AE2B8DB57E00F62617 /* NavigationRouter.swift */; };
 		09F3BD9C2BA9EAE90087E5FC /* Lottie in Frameworks */ = {isa = PBXBuildFile; productRef = 09F3BD9B2BA9EAE90087E5FC /* Lottie */; };
-		09F3BDF62BAC13E30087E5FC /* APIKEYS.plist in Resources */ = {isa = PBXBuildFile; fileRef = 09F3BDF42BAC13E30087E5FC /* APIKEYS.plist */; };
-		09F3BDF72BAC13E30087E5FC /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 09F3BDF52BAC13E30087E5FC /* GoogleService-Info.plist */; };
 		09F3BDF92BAC13EB0087E5FC /* DrinkLoading.json in Resources */ = {isa = PBXBuildFile; fileRef = 09F3BDF82BAC13EB0087E5FC /* DrinkLoading.json */; };
 		09F869932B68E36800A56A4C /* Formatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09F869922B68E36800A56A4C /* Formatter.swift */; };
 		09F869962B68E46500A56A4C /* DrinkDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09F869952B68E46500A56A4C /* DrinkDetailView.swift */; };
@@ -90,9 +90,6 @@
 		2C63DD672B67EB1B00770E3A /* RecordView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C63DD662B67EB1B00770E3A /* RecordView.swift */; };
 		2C69CDAC2B9DF61600F70F80 /* RecordViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C69CDAB2B9DF61600F70F80 /* RecordViewModel.swift */; };
 		2C7FD5522B848EEF00169512 /* Post.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C7FD5512B848EEF00169512 /* Post.swift */; };
-		2C8E1BFA2BA80A77009B0714 /* DrinkLoading.json in Resources */ = {isa = PBXBuildFile; fileRef = 2C8E1BF92BA80A77009B0714 /* DrinkLoading.json */; };
-		2C8E1C002BA80B47009B0714 /* APIKEYS.plist in Resources */ = {isa = PBXBuildFile; fileRef = 2C8E1BFF2BA80B47009B0714 /* APIKEYS.plist */; };
-		2C8E1C022BA80B6B009B0714 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 2C8E1C012BA80B6B009B0714 /* GoogleService-Info.plist */; };
 		2CACB53C2B99BAC500DD6DCE /* FireStorageService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CACB53B2B99BAC500DD6DCE /* FireStorageService.swift */; };
 		7B0A8BC52B8C163E00740E61 /* Report.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B0A8BC42B8C163E00740E61 /* Report.swift */; };
 		7B0A8BCD2B8CA7E900740E61 /* PostSearchList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B0A8BCC2B8CA7E900740E61 /* PostSearchList.swift */; };
@@ -184,6 +181,8 @@
 		093357B92B8E120200A9ACAB /* ErrorPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorPageView.swift; sourceTree = "<group>"; };
 		093357CE2B95505B00A9ACAB /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		094D07F72BA7C2F200904E73 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
+		09506F4A2BAC929A000557BE /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "../../../흐르미/GoogleService-Info.plist"; sourceTree = "<group>"; };
+		09506F4B2BAC929A000557BE /* APIKEYS.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = APIKEYS.plist; path = "../../../흐르미/APIKEYS.plist"; sourceTree = "<group>"; };
 		095D708C2B98200B00F76C11 /* FirebaseUserService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseUserService.swift; sourceTree = "<group>"; };
 		095D70902B99BD1400F76C11 /* UserViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserViewModel.swift; sourceTree = "<group>"; };
 		095D70922B99EAA500F76C11 /* MainViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewModel.swift; sourceTree = "<group>"; };
@@ -225,8 +224,6 @@
 		09BCC1592B7C8CD300FF4D1B /* IdentityVerificationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentityVerificationView.swift; sourceTree = "<group>"; };
 		09BCC15E2B7CFC7E00FF4D1B /* TermsAndVerificationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TermsAndVerificationView.swift; sourceTree = "<group>"; };
 		09C7C9AE2B8DB57E00F62617 /* NavigationRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationRouter.swift; sourceTree = "<group>"; };
-		09F3BDF42BAC13E30087E5FC /* APIKEYS.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = APIKEYS.plist; path = "../../../흐르미/APIKEYS.plist"; sourceTree = "<group>"; };
-		09F3BDF52BAC13E30087E5FC /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "../../../흐르미/GoogleService-Info.plist"; sourceTree = "<group>"; };
 		09F3BDF82BAC13EB0087E5FC /* DrinkLoading.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = DrinkLoading.json; path = "../../../../../흐르미/Lottie/DrinkLoading.json"; sourceTree = "<group>"; };
 		09F869922B68E36800A56A4C /* Formatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Formatter.swift; sourceTree = "<group>"; };
 		09F869952B68E46500A56A4C /* DrinkDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrinkDetailView.swift; sourceTree = "<group>"; };
@@ -254,9 +251,6 @@
 		2C63DD662B67EB1B00770E3A /* RecordView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordView.swift; sourceTree = "<group>"; };
 		2C69CDAB2B9DF61600F70F80 /* RecordViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordViewModel.swift; sourceTree = "<group>"; };
 		2C7FD5512B848EEF00169512 /* Post.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Post.swift; sourceTree = "<group>"; };
-		2C8E1BF92BA80A77009B0714 /* DrinkLoading.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = DrinkLoading.json; path = "../../../../../HrMi-JUDA/Lottie/DrinkLoading.json"; sourceTree = "<group>"; };
-		2C8E1BFF2BA80B47009B0714 /* APIKEYS.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = APIKEYS.plist; sourceTree = "<group>"; };
-		2C8E1C012BA80B6B009B0714 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		2CACB53B2B99BAC500DD6DCE /* FireStorageService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FireStorageService.swift; sourceTree = "<group>"; };
 		7B0A8BC42B8C163E00740E61 /* Report.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Report.swift; sourceTree = "<group>"; };
 		7B0A8BCC2B8CA7E900740E61 /* PostSearchList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostSearchList.swift; sourceTree = "<group>"; };
@@ -429,7 +423,6 @@
 		09BCC1482B7C7E1500FF4D1B /* Lottie */ = {
 			isa = PBXGroup;
 			children = (
-				2C8E1BF92BA80A77009B0714 /* DrinkLoading.json */,
 				09BCC14E2B7C7E2900FF4D1B /* Clouds.json */,
 				09BCC1492B7C7E2900FF4D1B /* Loading.json */,
 				09F3BDF82BAC13EB0087E5FC /* DrinkLoading.json */,
@@ -571,9 +564,9 @@
 				B121A5652B5F8D2000667D42 /* Resource */,
 				B1B8FE802B5EA9DA00921BBE /* Assets.xcassets */,
 				B1B8FE8C2B5EAAAB00921BBE /* Colors.xcassets */,
-				2C8E1BFF2BA80B47009B0714 /* APIKEYS.plist */,
-				2C8E1C012BA80B6B009B0714 /* GoogleService-Info.plist */,
 				B121A56F2B5F8DA100667D42 /* Info.plist */,
+				09506F4B2BAC929A000557BE /* APIKEYS.plist */,
+				09506F4A2BAC929A000557BE /* GoogleService-Info.plist */,
 				B1B8FE822B5EA9DA00921BBE /* Preview Content */,
 			);
 			path = JUDA;
@@ -871,7 +864,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				09BCC1512B7C7E2900FF4D1B /* Sun.json in Resources */,
-				2C8E1BFA2BA80A77009B0714 /* DrinkLoading.json in Resources */,
 				09BCC1502B7C7E2900FF4D1B /* Thunder.json in Resources */,
 				B1B8FE8D2B5EAAAB00921BBE /* Colors.xcassets in Resources */,
 				B121A5732B5F910900667D42 /* Pretendard-Bold.otf in Resources */,
@@ -883,10 +875,12 @@
 				09BCC1532B7C7E2900FF4D1B /* Snow.json in Resources */,
 				09BCC1542B7C7E2900FF4D1B /* Clouds.json in Resources */,
 				B121A5742B5F910B00667D42 /* Pretendard-Light.otf in Resources */,
+				09506F4C2BAC929A000557BE /* GoogleService-Info.plist in Resources */,
 				09BCC1522B7C7E2900FF4D1B /* Rain.json in Resources */,
 				B121A5762B5F911700667D42 /* Pretendard-Regular.otf in Resources */,
 				B1B8FE812B5EA9DA00921BBE /* Assets.xcassets in Resources */,
 				B121A5752B5F911500667D42 /* Pretendard-Medium.otf in Resources */,
+				09506F4D2BAC929A000557BE /* APIKEYS.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1159,12 +1153,10 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = JUDA/JUDA.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 6;
 				DEVELOPMENT_ASSET_PATHS = "\"JUDA/Preview Content\"";
-				DEVELOPMENT_TEAM = "";
-				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = CT6J74BCFP;
+				DEVELOPMENT_TEAM = CT6J74BCFP;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = JUDA/Info.plist;
@@ -1188,7 +1180,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.hrmi.juda;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = dev_JUDA;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1202,12 +1193,10 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = JUDA/JUDA.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 6;
 				DEVELOPMENT_ASSET_PATHS = "\"JUDA/Preview Content\"";
-				DEVELOPMENT_TEAM = "";
-				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = CT6J74BCFP;
+				DEVELOPMENT_TEAM = CT6J74BCFP;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = JUDA/Info.plist;
@@ -1231,7 +1220,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.hrmi.juda;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = dev_JUDA;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/JUDA_iOS/JUDA.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/JUDA_iOS/JUDA.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,13 +1,12 @@
 {
-  "originHash" : "9d00d6d19aea4480f6191998a2ec62f9eee0bcf6df419b0690743e83bbd804c1",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/abseil-cpp-binary.git",
       "state" : {
-        "revision" : "df308b8b46607675f2b9ec8e569109008f9155ce",
-        "version" : "1.2022062300.1"
+        "revision" : "7ce7be095bc3ed3c98b009532fe2d7698c132614",
+        "version" : "1.2024011601.0"
       }
     },
     {
@@ -33,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/firebase-ios-sdk",
       "state" : {
-        "revision" : "be49849dcba96f2b5ee550d4eceb2c0fa27dade4",
-        "version" : "10.22.1"
+        "revision" : "fcf5ced6dae2d43fced2581e673cc3b59bdb8ffa",
+        "version" : "10.23.0"
       }
     },
     {
@@ -42,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleAppMeasurement.git",
       "state" : {
-        "revision" : "482cfa4e5880f0a29f66ecfd60c5a62af28bd1f0",
-        "version" : "10.22.1"
+        "revision" : "6ec4ca62b00a665fa09b594fab897753a8c635fa",
+        "version" : "10.23.0"
       }
     },
     {
@@ -78,8 +77,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/grpc-binary.git",
       "state" : {
-        "revision" : "ea4cb5cc0c39c732b85386263116d2e2fdbbdc61",
-        "version" : "1.49.2"
+        "revision" : "67043f6389d0e28b38fa02d1c6952afeb04d807f",
+        "version" : "1.62.1"
       }
     },
     {
@@ -87,8 +86,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/gtm-session-fetcher.git",
       "state" : {
-        "revision" : "76135c9f4e1ac85459d5fec61b6f76ac47ab3a4c",
-        "version" : "3.3.1"
+        "revision" : "9534039303015a84837090d20fa21cae6e5eadb6",
+        "version" : "3.3.2"
       }
     },
     {
@@ -173,5 +172,5 @@
       }
     }
   ],
-  "version" : 3
+  "version" : 2
 }

--- a/JUDA_iOS/JUDA.xcodeproj/xcshareddata/xcschemes/JUDA.xcscheme
+++ b/JUDA_iOS/JUDA.xcodeproj/xcshareddata/xcschemes/JUDA.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1530"
-   version = "1.7">
+   version = "1.8">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES"
@@ -42,8 +42,7 @@
       allowLocationSimulation = "YES">
       <PathRunnable
          runnableDebuggingMode = "0"
-         BundleIdentifier = "com.hrmi.juda"
-         FilePath = "/Users/chung-inseon/Library/Developer/Xcode/DerivedData/JUDA-alivsugfiknafgevihdwjnmwgsbv/Build/Products/Debug-iphoneos/JUDA.app">
+         FilePath = "/Users/phang/Library/Developer/Xcode/DerivedData/JUDA-cosstivdqydphqdalurmudoqzqie/Build/Products/Debug-iphoneos/JUDA.app">
       </PathRunnable>
       <MacroExpansion>
          <BuildableReference

--- a/JUDA_iOS/JUDA/Info.plist
+++ b/JUDA_iOS/JUDA/Info.plist
@@ -19,7 +19,7 @@
 			<string>Editor</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
-				<string>com.googleusercontent.apps.246674821039-1p5kq98puu03t0mefug099lgjmeeqnpk</string>
+				<string>com.googleusercontent.apps.528456942179-cj2hrssfud9jj2m4bi387gai5ljm4tb4</string>
 			</array>
 		</dict>
 	</array>

--- a/JUDA_iOS/JUDA/Model/User.swift
+++ b/JUDA_iOS/JUDA/Model/User.swift
@@ -8,6 +8,7 @@
 import Foundation
 import FirebaseFirestore
 
+// MARK: - User
 // Firebase users 컬렉션 데이터 모델
 struct User {
     var userField: UserField
@@ -29,6 +30,13 @@ struct UserField: Codable {
     var authProviders: String // AuthProviderOption - rawValue
 }
 
+extension User: Equatable {
+    static func == (lhs: User, rhs: User) -> Bool {
+        lhs.userField.userID == rhs.userField.userID
+    }
+}
+
+// MARK: - UserNotification
 struct UserNotification: Equatable {
     @DocumentID var userNotificationID: String?
     var notificationField: NotificationField

--- a/JUDA_iOS/JUDA/View/DrinkInfo/DrinkInfoView.swift
+++ b/JUDA_iOS/JUDA/View/DrinkInfo/DrinkInfoView.swift
@@ -182,7 +182,7 @@ struct DrinkInfoView: View {
                                         searchTagType: searchTagType,
                                         postSearchText: postSearchText)
                 case .NavigationProfile(let userID,
-                                      let usedTo):
+                                        let usedTo):
                     NavigationProfileView(userID: userID,
                                           usedTo: usedTo)
                 case .Record(let recordType):

--- a/JUDA_iOS/JUDA/View/LogIn/ProfileSettingView.swift
+++ b/JUDA_iOS/JUDA/View/LogIn/ProfileSettingView.swift
@@ -60,7 +60,7 @@ struct ProfileSettingView: View {
                 ScrollView {
                     // 프로필 사진 선택
                     ZStack(alignment: .bottomTrailing) {
-                        // TODO: - 프로필 사진
+                        // 프로필 사진
                         if let image = userProfileImage {
                             Image(uiImage: image)
                                 .resizable()
@@ -192,8 +192,8 @@ struct ProfileSettingView: View {
                                 notification: notificationAllowed
                             )
                         authViewModel.isLoading = false
+                        navigationRouter.clear()
                     }
-                    navigationRouter.back()
                 } label: {
                     Text("완료")
                         .font(.medium20)

--- a/JUDA_iOS/JUDA/View/Main/MainView.swift
+++ b/JUDA_iOS/JUDA/View/Main/MainView.swift
@@ -84,6 +84,11 @@ struct MainView: View {
                 // 로그인 한 경우 알림권한 받아옴
                 if newValue {
                     appViewModel.setUserNotificationOption()
+                }
+            }
+            .onChange(of: authViewModel.currentUser) { _ in
+                // fcmToken 받아오기
+                if authViewModel.signInStatus {
                     Task {
                         if let user = authViewModel.currentUser?.userField,
                            let uid = user.userID {

--- a/JUDA_iOS/JUDA/View/Mypage/AuthenticatedMypageView.swift
+++ b/JUDA_iOS/JUDA/View/Mypage/AuthenticatedMypageView.swift
@@ -10,7 +10,6 @@ import FirebaseAuth
 
 // MARK: - 마이페이지 탭
 struct AuthenticatedMypageView: View {
-    @EnvironmentObject private var appViewModel: AppViewModel
     @EnvironmentObject private var authViewModel: AuthViewModel
     @EnvironmentObject private var recordViewModel: RecordViewModel
     
@@ -62,31 +61,8 @@ struct AuthenticatedMypageView: View {
                 .frame(maxHeight: .infinity, alignment: .center)
             }
         }
-        .toolbar {
-            ToolbarItem(placement: .topBarLeading) {
-                Text("마이페이지")
-                    .font(.semibold18)
-            }
-            // 알람 모아보는 뷰
-            ToolbarItem(placement: .topBarTrailing) {
-                NavigationLink(value: Route.AlarmStore) {
-                    Image(systemName: "bell")
-                }
-            }
-            // 환경설정 세팅 뷰
-            ToolbarItem(placement: .topBarTrailing) {
-                NavigationLink(value: Route.Setting) {
-                    Image(systemName: "gearshape")
-                }
-            }
+        .task {
+            await authViewModel.startListeningForUserField()
         }
-        .foregroundStyle(.mainBlack)
-        .onAppear {
-            appViewModel.tabBarState = .visible
-            Task {
-                await authViewModel.startListeningForUserField()
-            }
-        }
-        .toolbar(appViewModel.tabBarState, for: .tabBar)
     }
 }

--- a/JUDA_iOS/JUDA/View/Mypage/MyPageView.swift
+++ b/JUDA_iOS/JUDA/View/Mypage/MyPageView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 // MARK: - My Page View
 struct MyPageView: View {
     @StateObject private var navigationRouter = NavigationRouter()
+    @EnvironmentObject private var appViewModel: AppViewModel
     @EnvironmentObject private var authViewModel: AuthViewModel
 
     var body: some View {
@@ -21,6 +22,28 @@ struct MyPageView: View {
                     UnauthenticatedMypageView()
                 }
             }
+            .navigationBarBackButtonHidden()
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Text("마이페이지")
+                        .font(.semibold18)
+                }
+                if authViewModel.signInStatus {
+                    // 알람 모아보는 뷰
+                    ToolbarItem(placement: .topBarTrailing) {
+                        NavigationLink(value: Route.AlarmStore) {
+                            Image(systemName: "bell")
+                        }
+                    }
+                }
+                // 환경설정 세팅 뷰
+                ToolbarItem(placement: .topBarTrailing) {
+                    NavigationLink(value: Route.Setting) {
+                        Image(systemName: "gearshape")
+                    }
+                }
+            }
+            .foregroundStyle(.mainBlack)
             .navigationDestination(for: Route.self) { value in
                 switch value {
                 case .ChangeUserName:
@@ -64,8 +87,11 @@ struct MyPageView: View {
                         .modifier(TabBarHidden())
                 }
             }
+            .onAppear {
+                appViewModel.tabBarState = .visible
+            }
         }
+        .toolbar(appViewModel.tabBarState, for: .tabBar)
         .environmentObject(navigationRouter)
     }
 }
-

--- a/JUDA_iOS/JUDA/View/Mypage/MypageDetail/AlarmStoreView.swift
+++ b/JUDA_iOS/JUDA/View/Mypage/MypageDetail/AlarmStoreView.swift
@@ -11,25 +11,36 @@ import FirebaseAuth
 // MARK: - 알람 쌓여있는 리스트 화면
 struct AlarmStoreView: View {
     @EnvironmentObject private var navigationRouter: NavigationRouter
+    @EnvironmentObject private var authViewModel: AuthViewModel
 
     var body: some View {
         VStack(spacing: 0) {
-            // 알람 리스트
-            // MARK: iOS 16.4 이상
-            if #available(iOS 16.4, *) {
-                ScrollView() {
-                    AlarmListContent()
-                }
-                .scrollBounceBehavior(.basedOnSize, axes: .vertical)
-            // MARK: iOS 16.4 미만
-            } else {
-                ViewThatFits(in: .vertical) {
-                    AlarmListContent()
-                        .frame(maxHeight: .infinity, alignment: .top)
-                    ScrollView {
+            if let user = authViewModel.currentUser,
+               !user.notifications.isEmpty {
+                // 알람 리스트
+                // MARK: iOS 16.4 이상
+                if #available(iOS 16.4, *) {
+                    ScrollView() {
                         AlarmListContent()
                     }
+                    .scrollBounceBehavior(.basedOnSize, axes: .vertical)
+                    // MARK: iOS 16.4 미만
+                } else {
+                    ViewThatFits(in: .vertical) {
+                        AlarmListContent()
+                            .frame(maxHeight: .infinity, alignment: .top)
+                        ScrollView {
+                            AlarmListContent()
+                        }
+                    }
                 }
+            } else {
+                VStack {
+                    Text("아직 도착한 알람이 없어요!")
+                        .font(.medium16)
+                        .foregroundStyle(.mainBlack)
+                }
+                .frame(maxHeight: .infinity, alignment: .center)
             }
         }
         .navigationBarBackButtonHidden()

--- a/JUDA_iOS/JUDA/View/Mypage/MypageDetail/UserProfileView.swift
+++ b/JUDA_iOS/JUDA/View/Mypage/MypageDetail/UserProfileView.swift
@@ -32,70 +32,66 @@ struct UserProfileView: View {
     }
     
     var body: some View {
-        ZStack {
-            HStack {
-                HStack(spacing: 20) {
-                    HStack(alignment: .bottom, spacing: -15) {
-                        // 사용자 프로필 이미지
-                        if let profileImageURL = profileImageURL {
-                            UserProfileKFImage(url: profileImageURL, userType: userType, selectedImage: selectedImage)
-                        } else {
-                            // 사용자 지정 이미지가 없을 때 기본 이미지로 설정
-                            Image("defaultprofileimage")
-                                .resizable()
-                                .aspectRatio(contentMode: .fill)
-                                .clipShape(Circle())
-                                .frame(width: 70, height: 70)
-                        }
-                        // 프로필 사진 수정 버튼
-                        if userType == .user {
-                            LibraryPhotosPicker(selectedPhotos: $selectedPhotos, maxSelectionCount: 1) { // 최대 1장
-                                Image(systemName: "pencil.circle.fill")
-                                    .resizable()
-                                    .aspectRatio(contentMode: .fill)
-                                    .frame(width: 20, height: 20)
-                                    .foregroundStyle(.gray01)
-                            }
-                            .onChange(of: selectedPhotos) { _ in
-                                Task {
-                                    do {
-                                        let uiImage = try await authViewModel.updateImage(selectedPhotos: selectedPhotos)
-                                        self.selectedImage = uiImage
-                                        let url = await authViewModel.uploadProfileImageToStorage(image: uiImage)
-                                        if authViewModel.currentUser?.userField.profileImageURL == nil {
-                                            await authViewModel.updateUserProfileImageURL(url: url)
-                                        }
-                                    } catch {
-                                        // 이미지 로드 실패 alert 띄워주기
-                                        showAlert = true
-                                    }
+        HStack(spacing: 20) {
+            HStack(alignment: .bottom, spacing: -15) {
+                // 사용자 프로필 이미지
+                if let profileImageURL = profileImageURL {
+                    UserProfileKFImage(url: profileImageURL, userType: userType, selectedImage: selectedImage)
+                } else {
+                    // 사용자 지정 이미지가 없을 때 기본 이미지로 설정
+                    Image("defaultprofileimage")
+                        .resizable()
+                        .aspectRatio(contentMode: .fill)
+                        .clipShape(Circle())
+                        .frame(width: 70, height: 70)
+                }
+                // 프로필 사진 수정 버튼
+                if userType == .user {
+                    LibraryPhotosPicker(selectedPhotos: $selectedPhotos, maxSelectionCount: 1) { // 최대 1장
+                        Image(systemName: "pencil.circle.fill")
+                            .resizable()
+                            .aspectRatio(contentMode: .fill)
+                            .frame(width: 20, height: 20)
+                            .foregroundStyle(.gray01)
+                    }
+                    .onChange(of: selectedPhotos) { _ in
+                        Task {
+                            do {
+                                let uiImage = try await authViewModel.updateImage(selectedPhotos: selectedPhotos)
+                                self.selectedImage = uiImage
+                                let url = await authViewModel.uploadProfileImageToStorage(image: uiImage)
+                                if authViewModel.currentUser?.userField.profileImageURL == nil {
+                                    await authViewModel.updateUserProfileImageURL(url: url)
                                 }
-                            }
-                            .tint(.mainBlack)
-                            .alert(isPresented: $showAlert) {
-                                Alert(title: Text("사진을 불러오는데 실패했어요\n다시 시도해주세요"),
-                                      dismissButton: .default(Text("확인"), action: { showAlert = false }))
+                            } catch {
+                                // 이미지 로드 실패 alert 띄워주기
+                                showAlert = true
                             }
                         }
                     }
-                    // 사용자 닉네임 표시
-                    Text(userType == .user ? authViewModel.currentUser?.userField.name ?? "" : userViewModel.user?.userField.name ?? "" )
-                    .font(.medium18)
-                    
-                    Spacer()
-                    // 닉네임 수정
-                    if userType == .user {
-                        NavigationLink(value: Route.ChangeUserName) {
-                            Text("닉네임 수정")
-                                .font(.regular14)
-                                .foregroundStyle(.gray01)
-                        }
+                    .tint(.mainBlack)
+                    .alert(isPresented: $showAlert) {
+                        Alert(title: Text("사진을 불러오는데 실패했어요\n다시 시도해주세요"),
+                              dismissButton: .default(Text("확인"), action: { showAlert = false }))
                     }
                 }
             }
-            .padding(.horizontal, 20)
-            .padding(.vertical, 10)
+            // 사용자 닉네임 표시
+            Text(userType == .user ? authViewModel.currentUser?.userField.name ?? "" : userViewModel.user?.userField.name ?? "" )
+            .font(.medium18)
+            
+            Spacer()
+            // 닉네임 수정
+            if userType == .user {
+                NavigationLink(value: Route.ChangeUserName) {
+                    Text("닉네임 수정")
+                        .font(.regular14)
+                        .foregroundStyle(.gray01)
+                }
+            }
         }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 10)
     }
 }
 

--- a/JUDA_iOS/JUDA/View/Mypage/SettingView.swift
+++ b/JUDA_iOS/JUDA/View/Mypage/SettingView.swift
@@ -161,13 +161,15 @@ struct SettingView: View {
                     },
                     rightButtonLabel: "로그아웃",
                     rightButtonAction: {
-                        // 로그아웃 - AppStorage 에서 변경
-                        authViewModel.signOut()
-                        //
-                        isLogoutClicked.toggle()
-                        navigationRouter.back()
-                        // MainView 로 보내기
-                        appViewModel.selectedTabIndex = 0
+                        Task {
+                            // 로그아웃 - AppStorage 에서 변경
+                            await authViewModel.signOut()
+                            //
+                            isLogoutClicked.toggle()
+                            navigationRouter.back()
+                            // MainView 로 보내기
+                            appViewModel.selectedTabIndex = 0
+                        }
                     })
                 )
             }

--- a/JUDA_iOS/JUDA/View/Mypage/UnauthenticatedMypageView.swift
+++ b/JUDA_iOS/JUDA/View/Mypage/UnauthenticatedMypageView.swift
@@ -9,8 +9,6 @@ import SwiftUI
 
 // MARK: - 로그인 X 일 경우 보여지는 MypageView
 struct UnauthenticatedMypageView: View {
-    @EnvironmentObject private var appViewModel: AppViewModel
-
     var body: some View {
         VStack {
             HStack(spacing: 20) {
@@ -43,22 +41,6 @@ struct UnauthenticatedMypageView: View {
                 .foregroundStyle(.gray01)
                 .multilineTextAlignment(.center)
             Spacer()
-        }
-        .toolbar {
-            ToolbarItem(placement: .topBarLeading) {
-                Text("마이페이지")
-                    .font(.semibold18)
-            }
-            // 환경설정 세팅 뷰
-            ToolbarItem(placement: .topBarTrailing) {
-                NavigationLink(value: Route.Setting) {
-                    Image(systemName: "gearshape")
-                }
-            }
-        }
-        .foregroundStyle(.mainBlack)
-        .onAppear {
-            appViewModel.tabBarState = .visible
         }
     }
 }

--- a/JUDA_iOS/JUDA/ViewModel/App/AppViewModel.swift
+++ b/JUDA_iOS/JUDA/ViewModel/App/AppViewModel.swift
@@ -13,7 +13,7 @@ import FirebaseMessaging
 final class AppViewModel: ObservableObject {
     // 탭바 상태
     @Published var tabBarState: Visibility = .visible
-    @Published var selectedTabIndex: Int = 0 // 추가
+    @Published var selectedTabIndex: Int = 0
     @Published var locationManager = LocationManager()
 	
 	private let firebaseAuthService = FirebaseAuthService()

--- a/JUDA_iOS/JUDA/ViewModel/Auth/AuthViewModel.swift
+++ b/JUDA_iOS/JUDA/ViewModel/Auth/AuthViewModel.swift
@@ -154,13 +154,13 @@ final class AuthViewModel: ObservableObject {
             // 프로필 이미지 storage 저장
             let url = await uploadProfileImageToStorage(image: profileImage)
             // 유저 이름, 생일, 성별, 프로필, 알림 동의 등 forestore 에 저장
-            addUserDataToStore(
+            await addUserDataToStore(
                 name: name,
                 age: age,
                 profileImageURL: url,
                 gender: gender,
                 notification: notification
-                )
+            )
             // 유저 데이터 받기
             await getCurrentUser()
         } catch {
@@ -444,7 +444,7 @@ extension AuthViewModel {
 extension AuthViewModel {
     // 유저 정보 저장
     func addUserDataToStore(name: String, age: Int, profileImageURL: URL?,
-                            gender: String, notification: Bool) {
+                            gender: String, notification: Bool) async {
         do {
             let uid = try checkCurrentUserID()
             firebaseAuthService.addUserDataToStore(
@@ -567,8 +567,8 @@ extension AuthViewModel {
     private func deleteAppleAccount() async -> Bool {
         do {
             guard try getProviderOptionString() == AuthProviderOption.apple.rawValue else { return false }
+            let uid = try checkCurrentUserID()
             try await firebaseAuthService.deleteAccountWithApple()
-			let uid = try checkCurrentUserID()
 			firebaseAuthService.deleteUserData(uid: uid)
             resetData()
             return true
@@ -621,8 +621,8 @@ extension AuthViewModel {
     private func deleteGoogleAccount() async -> Bool {
         do {
             guard try getProviderOptionString() == AuthProviderOption.google.rawValue else { return false }
-            try await firebaseAuthService.deleteAccountWithGoogle()
             let uid = try checkCurrentUserID()
+            try await firebaseAuthService.deleteAccountWithGoogle()
             firebaseAuthService.deleteUserData(uid: uid)
             resetData()
             return true

--- a/JUDA_iOS/JUDA/ViewModel/Auth/AuthViewModel.swift
+++ b/JUDA_iOS/JUDA/ViewModel/Auth/AuthViewModel.swift
@@ -47,11 +47,13 @@ final class AuthViewModel: ObservableObject {
     private let drinkCollection = "drinks"
     
     // 현재 유저 있는지 확인, uid 받기
-    private func checkCurrentUserID() throws -> String {
+    private func checkCurrentUserID()  throws -> String {
         guard let uid = Auth.auth().currentUser?.uid else {
             print("error :: currentUser 없음")
             defer {
-                signOut()
+                Task {
+                    await signOut()
+                }
             }
             throw AuthManagerError.noUserID
         }
@@ -483,7 +485,7 @@ extension AuthViewModel {
 // MARK: - 로그아웃 ( Apple & Google 공통 )
 extension AuthViewModel {
     // 로그아웃
-    func signOut() {
+    func signOut() async {
         do {
             try Auth.auth().signOut()
             resetData()
@@ -526,7 +528,7 @@ extension AuthViewModel {
                 isNewUser = await firebaseAuthService.isNewUser(uid: uid)
                 // 신규 유저
                 if isNewUser {
-                    signOut()
+                    await signOut()
                     self.isNewUser = true
                     print("First ✨ - Apple Sign Up 🍎")
                 } else {


### PR DESCRIPTION
## 개요 (이슈 번호 및 요약)
- #166 

## 변경 사항 (작업 내용)

### 로그아웃 시, 로그아웃 이전에 네비게이션이 이동하는 문제
( mainView 로 왔을 때, 로그아웃이 되기 전이라, 데이터 fetch 를 요청 )
- 로그아웃 : signOut 메서드를 async 로 수정
- 로그아웃 시, Task 블록 안에서 signOut 이후에 화면 전환 로직 실행

### apple계정 로그아웃하고 sign in Google 클릭 시 튕김. 탈퇴하고 눌러도 튕김
- Error 메세지 검색 결과
- GoogleService-Info.plist 의 REVERSED_CLIENT_ID 를 app 의 info 에 URL Types 에 추가해 줘야 하는 것을 확인
( 이전에 추가가 되어있었으나, GoogleService-Info.plist 수정 후, 값을 교체하지 않았음 )

### fcmToken 에러 수정
- 회원가입 시, fcmToken 바로 받아오지 못하는 문제 수정
- currentUser 를 받아오는 것이, 로그인 완료 시점보다 뒤에 있었던 문제

### 그 외
- whiteSpace 및 주석 지우기
- 알림 없을 때, 알림 리스트에 텍스트 "아직 도착한 알람이 없어요!" 보이기
- UserProfileView 뷰에 있는 불필요 stack 삭제
- MyPageView 의 toolbar 하위뷰에서 각각 중복 선언된 코드 상위뷰에서 한번만 사용하도록 수정