### PR TITLE
[Refactoring] NavigationPostsView 탭뷰, LoginDialog(CustomDialog) 오류 해결 #178

### DIFF
--- a/JUDA_iOS/JUDA.xcodeproj/project.pbxproj
+++ b/JUDA_iOS/JUDA.xcodeproj/project.pbxproj
@@ -20,8 +20,6 @@
 		093357CB2B954A8A00A9ACAB /* GoogleSignInSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 093357CA2B954A8A00A9ACAB /* GoogleSignInSwift */; };
 		093357CF2B95505E00A9ACAB /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 093357CE2B95505B00A9ACAB /* AppDelegate.swift */; };
 		094D07F82BA7C2F200904E73 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 094D07F72BA7C2F200904E73 /* Constants.swift */; };
-		09506F4C2BAC929A000557BE /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 09506F4A2BAC929A000557BE /* GoogleService-Info.plist */; };
-		09506F4D2BAC929A000557BE /* APIKEYS.plist in Resources */ = {isa = PBXBuildFile; fileRef = 09506F4B2BAC929A000557BE /* APIKEYS.plist */; };
 		095D708D2B98200B00F76C11 /* FirebaseUserService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 095D708C2B98200B00F76C11 /* FirebaseUserService.swift */; };
 		095D70912B99BD1400F76C11 /* UserViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 095D70902B99BD1400F76C11 /* UserViewModel.swift */; };
 		095D70932B99EAA500F76C11 /* MainViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 095D70922B99EAA500F76C11 /* MainViewModel.swift */; };
@@ -64,7 +62,6 @@
 		09BCC15F2B7CFC7E00FF4D1B /* TermsAndVerificationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09BCC15E2B7CFC7E00FF4D1B /* TermsAndVerificationView.swift */; };
 		09C7C9AF2B8DB57E00F62617 /* NavigationRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09C7C9AE2B8DB57E00F62617 /* NavigationRouter.swift */; };
 		09F3BD9C2BA9EAE90087E5FC /* Lottie in Frameworks */ = {isa = PBXBuildFile; productRef = 09F3BD9B2BA9EAE90087E5FC /* Lottie */; };
-		09F3BDF92BAC13EB0087E5FC /* DrinkLoading.json in Resources */ = {isa = PBXBuildFile; fileRef = 09F3BDF82BAC13EB0087E5FC /* DrinkLoading.json */; };
 		09F869932B68E36800A56A4C /* Formatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09F869922B68E36800A56A4C /* Formatter.swift */; };
 		09F869962B68E46500A56A4C /* DrinkDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09F869952B68E46500A56A4C /* DrinkDetailView.swift */; };
 		09F869982B68E48400A56A4C /* DrinkDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09F869972B68E48400A56A4C /* DrinkDetails.swift */; };
@@ -78,8 +75,6 @@
 		09F869BB2B6A4A9C00A56A4C /* LikedDrinkList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09F869BA2B6A4A9C00A56A4C /* LikedDrinkList.swift */; };
 		09F869BD2B6A4AAE00A56A4C /* LikedPostGrid.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09F869BC2B6A4AAE00A56A4C /* LikedPostGrid.swift */; };
 		2C2044E82B63B9D600773266 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C2044E72B63B9D600773266 /* ContentView.swift */; };
-		2C22D7B32BAC94980082CE0F /* APIKEYS.plist in Resources */ = {isa = PBXBuildFile; fileRef = 2C22D7B22BAC94980082CE0F /* APIKEYS.plist */; };
-		2C22D7B72BAC94C90082CE0F /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 2C22D7B62BAC94C90082CE0F /* GoogleService-Info.plist */; };
 		2C2AD4FD2B68891C00C681F4 /* SearchTagView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C2AD4FC2B68891C00C681F4 /* SearchTagView.swift */; };
 		2C2AD5012B689CA500C681F4 /* SelectedPhotoHorizontalScroll.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C2AD5002B689CA500C681F4 /* SelectedPhotoHorizontalScroll.swift */; };
 		2C2AD5032B68A15E00C681F4 /* FoodTagAddTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C2AD5022B68A15E00C681F4 /* FoodTagAddTextField.swift */; };
@@ -92,6 +87,9 @@
 		2C63DD672B67EB1B00770E3A /* RecordView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C63DD662B67EB1B00770E3A /* RecordView.swift */; };
 		2C69CDAC2B9DF61600F70F80 /* RecordViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C69CDAB2B9DF61600F70F80 /* RecordViewModel.swift */; };
 		2C7FD5522B848EEF00169512 /* Post.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C7FD5512B848EEF00169512 /* Post.swift */; };
+		2C9707442BC5144F001D57D5 /* APIKEYS.plist in Resources */ = {isa = PBXBuildFile; fileRef = 2C9707422BC5144F001D57D5 /* APIKEYS.plist */; };
+		2C9707452BC5144F001D57D5 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 2C9707432BC5144F001D57D5 /* GoogleService-Info.plist */; };
+		2C9707472BC51486001D57D5 /* DrinkLoading.json in Resources */ = {isa = PBXBuildFile; fileRef = 2C9707462BC51486001D57D5 /* DrinkLoading.json */; };
 		2CACB53C2B99BAC500DD6DCE /* FireStorageService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CACB53B2B99BAC500DD6DCE /* FireStorageService.swift */; };
 		7B0A8BC52B8C163E00740E61 /* Report.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B0A8BC42B8C163E00740E61 /* Report.swift */; };
 		7B0A8BCD2B8CA7E900740E61 /* PostSearchList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B0A8BCC2B8CA7E900740E61 /* PostSearchList.swift */; };
@@ -119,9 +117,6 @@
 		7BBDFF702B6B90EB0036FB8B /* PostGrid.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B6D76B62B68972000601B55 /* PostGrid.swift */; };
 		7BBDFF722B6B912C0036FB8B /* TabItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C63DD512B676E1000770E3A /* TabItem.swift */; };
 		7BBDFF732B6B912C0036FB8B /* DrinkInfoSegment.swift in Sources */ = {isa = PBXBuildFile; fileRef = B16EB85B2B63859800E920A3 /* DrinkInfoSegment.swift */; };
-		7BD26B452BADBFEF0036EB91 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 7BD26B432BADBFEF0036EB91 /* GoogleService-Info.plist */; };
-		7BD26B462BADBFEF0036EB91 /* APIKEYS.plist in Resources */ = {isa = PBXBuildFile; fileRef = 7BD26B442BADBFEF0036EB91 /* APIKEYS.plist */; };
-		7BD26B482BADC00F0036EB91 /* DrinkLoading.json in Resources */ = {isa = PBXBuildFile; fileRef = 7BD26B472BADC00F0036EB91 /* DrinkLoading.json */; };
 		7BE14B952B84733900C1F6C3 /* Drink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BE14B942B84733900C1F6C3 /* Drink.swift */; };
 		7BE14B972B84767000C1F6C3 /* DrinkUploadViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BE14B962B84767000C1F6C3 /* DrinkUploadViewModel.swift */; };
 		AC110B572B69658C005390BB /* ChangeUserNameView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC110B562B69658C005390BB /* ChangeUserNameView.swift */; };
@@ -186,8 +181,6 @@
 		093357B92B8E120200A9ACAB /* ErrorPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorPageView.swift; sourceTree = "<group>"; };
 		093357CE2B95505B00A9ACAB /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		094D07F72BA7C2F200904E73 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
-		09506F4A2BAC929A000557BE /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "../../../흐르미/GoogleService-Info.plist"; sourceTree = "<group>"; };
-		09506F4B2BAC929A000557BE /* APIKEYS.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = APIKEYS.plist; path = "../../../흐르미/APIKEYS.plist"; sourceTree = "<group>"; };
 		095D708C2B98200B00F76C11 /* FirebaseUserService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseUserService.swift; sourceTree = "<group>"; };
 		095D70902B99BD1400F76C11 /* UserViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserViewModel.swift; sourceTree = "<group>"; };
 		095D70922B99EAA500F76C11 /* MainViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewModel.swift; sourceTree = "<group>"; };
@@ -229,7 +222,6 @@
 		09BCC1592B7C8CD300FF4D1B /* IdentityVerificationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentityVerificationView.swift; sourceTree = "<group>"; };
 		09BCC15E2B7CFC7E00FF4D1B /* TermsAndVerificationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TermsAndVerificationView.swift; sourceTree = "<group>"; };
 		09C7C9AE2B8DB57E00F62617 /* NavigationRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationRouter.swift; sourceTree = "<group>"; };
-		09F3BDF82BAC13EB0087E5FC /* DrinkLoading.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = DrinkLoading.json; path = "../../../../../흐르미/Lottie/DrinkLoading.json"; sourceTree = "<group>"; };
 		09F869922B68E36800A56A4C /* Formatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Formatter.swift; sourceTree = "<group>"; };
 		09F869952B68E46500A56A4C /* DrinkDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrinkDetailView.swift; sourceTree = "<group>"; };
 		09F869972B68E48400A56A4C /* DrinkDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrinkDetails.swift; sourceTree = "<group>"; };
@@ -243,8 +235,6 @@
 		09F869BA2B6A4A9C00A56A4C /* LikedDrinkList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LikedDrinkList.swift; sourceTree = "<group>"; };
 		09F869BC2B6A4AAE00A56A4C /* LikedPostGrid.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LikedPostGrid.swift; sourceTree = "<group>"; };
 		2C2044E72B63B9D600773266 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
-		2C22D7B22BAC94980082CE0F /* APIKEYS.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = APIKEYS.plist; path = "../../../HrMi-JUDA/APIKEY & plist.plist/APIKEYS.plist"; sourceTree = "<group>"; };
-		2C22D7B62BAC94C90082CE0F /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "../../../HrMi-JUDA/APIKEY & plist.plist/GoogleService-Info.plist"; sourceTree = "<group>"; };
 		2C2AD4FC2B68891C00C681F4 /* SearchTagView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchTagView.swift; sourceTree = "<group>"; };
 		2C2AD5002B689CA500C681F4 /* SelectedPhotoHorizontalScroll.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectedPhotoHorizontalScroll.swift; sourceTree = "<group>"; };
 		2C2AD5022B68A15E00C681F4 /* FoodTagAddTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoodTagAddTextField.swift; sourceTree = "<group>"; };
@@ -258,6 +248,9 @@
 		2C63DD662B67EB1B00770E3A /* RecordView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordView.swift; sourceTree = "<group>"; };
 		2C69CDAB2B9DF61600F70F80 /* RecordViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordViewModel.swift; sourceTree = "<group>"; };
 		2C7FD5512B848EEF00169512 /* Post.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Post.swift; sourceTree = "<group>"; };
+		2C9707422BC5144F001D57D5 /* APIKEYS.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = APIKEYS.plist; path = "../../../HrMi-JUDA/APIKEY & plist.plist/APIKEYS.plist"; sourceTree = "<group>"; };
+		2C9707432BC5144F001D57D5 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "../../../HrMi-JUDA/APIKEY & plist.plist/GoogleService-Info.plist"; sourceTree = "<group>"; };
+		2C9707462BC51486001D57D5 /* DrinkLoading.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = DrinkLoading.json; path = "../../../../../HrMi-JUDA/Lottie/DrinkLoading.json"; sourceTree = "<group>"; };
 		2CACB53B2B99BAC500DD6DCE /* FireStorageService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FireStorageService.swift; sourceTree = "<group>"; };
 		7B0A8BC42B8C163E00740E61 /* Report.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Report.swift; sourceTree = "<group>"; };
 		7B0A8BCC2B8CA7E900740E61 /* PostSearchList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostSearchList.swift; sourceTree = "<group>"; };
@@ -280,9 +273,6 @@
 		7B92656C2B692F0700840095 /* PostReportContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostReportContent.swift; sourceTree = "<group>"; };
 		7B92656E2B69303F00840095 /* PostReportButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostReportButton.swift; sourceTree = "<group>"; };
 		7B9265702B6941D000840095 /* PostReportToolbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostReportToolbar.swift; sourceTree = "<group>"; };
-		7BD26B432BADBFEF0036EB91 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "../../../../../../JUDA_file/GoogleService-Info.plist"; sourceTree = "<group>"; };
-		7BD26B442BADBFEF0036EB91 /* APIKEYS.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = APIKEYS.plist; path = ../../../../../../JUDA_file/APIKEYS.plist; sourceTree = "<group>"; };
-		7BD26B472BADC00F0036EB91 /* DrinkLoading.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = DrinkLoading.json; path = ../../../../../../../../JUDA_file/Lottie/DrinkLoading.json; sourceTree = "<group>"; };
 		7BE14B942B84733900C1F6C3 /* Drink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Drink.swift; sourceTree = "<group>"; };
 		7BE14B962B84767000C1F6C3 /* DrinkUploadViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrinkUploadViewModel.swift; sourceTree = "<group>"; };
 		AC110B562B69658C005390BB /* ChangeUserNameView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeUserNameView.swift; sourceTree = "<group>"; };
@@ -433,10 +423,10 @@
 		09BCC1482B7C7E1500FF4D1B /* Lottie */ = {
 			isa = PBXGroup;
 			children = (
-				7BD26B472BADC00F0036EB91 /* DrinkLoading.json */,
 				09BCC14E2B7C7E2900FF4D1B /* Clouds.json */,
 				09BCC1492B7C7E2900FF4D1B /* Loading.json */,
 				09BCC14C2B7C7E2900FF4D1B /* Rain.json */,
+				2C9707462BC51486001D57D5 /* DrinkLoading.json */,
 				09BCC14D2B7C7E2900FF4D1B /* Snow.json */,
 				09BCC14B2B7C7E2900FF4D1B /* Sun.json */,
 				09BCC14A2B7C7E2900FF4D1B /* Thunder.json */,
@@ -465,6 +455,13 @@
 				2C63DD512B676E1000770E3A /* TabItem.swift */,
 			);
 			path = ContentView;
+			sourceTree = "<group>";
+		};
+		2C9707412BC513BE001D57D5 /* Recovered References */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = "Recovered References";
 			sourceTree = "<group>";
 		};
 		7B0A8BCA2B8CA77400740E61 /* PostDetail */ = {
@@ -559,6 +556,7 @@
 			children = (
 				B1B8FE7B2B5EA9D900921BBE /* JUDA */,
 				7B56AE152BA66C8200C47F3C /* Frameworks */,
+				2C9707412BC513BE001D57D5 /* Recovered References */,
 			);
 			sourceTree = "<group>";
 		};
@@ -575,8 +573,8 @@
 				B1B8FE802B5EA9DA00921BBE /* Assets.xcassets */,
 				B1B8FE8C2B5EAAAB00921BBE /* Colors.xcassets */,
 				B121A56F2B5F8DA100667D42 /* Info.plist */,
-				2C22D7B22BAC94980082CE0F /* APIKEYS.plist */,
-				2C22D7B62BAC94C90082CE0F /* GoogleService-Info.plist */,
+				2C9707422BC5144F001D57D5 /* APIKEYS.plist */,
+				2C9707432BC5144F001D57D5 /* GoogleService-Info.plist */,
 				B1B8FE822B5EA9DA00921BBE /* Preview Content */,
 			);
 			path = JUDA;
@@ -874,7 +872,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				09BCC1512B7C7E2900FF4D1B /* Sun.json in Resources */,
-				7BD26B482BADC00F0036EB91 /* DrinkLoading.json in Resources */,
+				2C9707472BC51486001D57D5 /* DrinkLoading.json in Resources */,
 				09BCC1502B7C7E2900FF4D1B /* Thunder.json in Resources */,
 				B1B8FE8D2B5EAAAB00921BBE /* Colors.xcassets in Resources */,
 				B121A5732B5F910900667D42 /* Pretendard-Bold.otf in Resources */,
@@ -883,15 +881,14 @@
 				B121A5782B5F911A00667D42 /* Pretendard-Thin.otf in Resources */,
 				B121A5772B5F911900667D42 /* Pretendard-SemiBold.otf in Resources */,
 				09BCC1532B7C7E2900FF4D1B /* Snow.json in Resources */,
-				2C22D7B72BAC94C90082CE0F /* GoogleService-Info.plist in Resources */,
 				09BCC1542B7C7E2900FF4D1B /* Clouds.json in Resources */,
 				B121A5742B5F910B00667D42 /* Pretendard-Light.otf in Resources */,
-				09506F4C2BAC929A000557BE /* GoogleService-Info.plist in Resources */,
 				09BCC1522B7C7E2900FF4D1B /* Rain.json in Resources */,
+				2C9707452BC5144F001D57D5 /* GoogleService-Info.plist in Resources */,
 				B121A5762B5F911700667D42 /* Pretendard-Regular.otf in Resources */,
 				B1B8FE812B5EA9DA00921BBE /* Assets.xcassets in Resources */,
 				B121A5752B5F911500667D42 /* Pretendard-Medium.otf in Resources */,
-				2C22D7B32BAC94980082CE0F /* APIKEYS.plist in Resources */,
+				2C9707442BC5144F001D57D5 /* APIKEYS.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1164,10 +1161,12 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = JUDA/JUDA.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 6;
 				DEVELOPMENT_ASSET_PATHS = "\"JUDA/Preview Content\"";
-				DEVELOPMENT_TEAM = CT6J74BCFP;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = CT6J74BCFP;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = JUDA/Info.plist;
@@ -1191,6 +1190,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.hrmi.juda;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = dev_JUDA;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1204,10 +1204,12 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = JUDA/JUDA.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 6;
 				DEVELOPMENT_ASSET_PATHS = "\"JUDA/Preview Content\"";
-				DEVELOPMENT_TEAM = CT6J74BCFP;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = CT6J74BCFP;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = JUDA/Info.plist;
@@ -1231,6 +1233,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.hrmi.juda;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = dis_JUDA;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/JUDA_iOS/JUDA/Resource/Components/CustomDialog.swift
+++ b/JUDA_iOS/JUDA/Resource/Components/CustomDialog.swift
@@ -60,6 +60,12 @@ struct CustomDialog: View {
             .background(.background)
             .cornerRadius(10)
         }
+        .onAppear {
+            UINavigationController.allowSwipeBack = false
+        }
+        .onDisappear {
+            UINavigationController.allowSwipeBack = true
+        }
         .navigationBarBackButtonHidden()
     }
     

--- a/JUDA_iOS/JUDA/Resource/UINavigationController +.swift
+++ b/JUDA_iOS/JUDA/Resource/UINavigationController +.swift
@@ -9,11 +9,16 @@ import SwiftUI
 
 // MARK: - 스와이프 뒤로가기 제스처
 extension UINavigationController: UIGestureRecognizerDelegate {
+    static var allowSwipeBack = true
+    
     override open func viewDidLoad() {
         super.viewDidLoad()
         interactivePopGestureRecognizer?.delegate = self
     }
     public func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
-        return viewControllers.count > 1
+        if UINavigationController.allowSwipeBack {
+            return viewControllers.count > 1
+        }
+        return false
     }
 }

--- a/JUDA_iOS/JUDA/View/DrinkInfo/DrinkDetail/DrinkDetailView.swift
+++ b/JUDA_iOS/JUDA/View/DrinkInfo/DrinkDetail/DrinkDetailView.swift
@@ -93,6 +93,7 @@ struct DrinkDetailView: View {
                 } label: {
                     Image(systemName: "chevron.backward")
                 }
+                .disabled(authViewModel.isShowLoginDialog)
             }
             ToolbarItem(placement: .topBarTrailing) {
                 // 공유하기
@@ -106,6 +107,7 @@ struct DrinkDetailView: View {
                 ) {
                     Image(systemName: "square.and.arrow.up")
                 }
+                .disabled(authViewModel.isShowLoginDialog)
             }
         }
         .tint(.mainBlack)

--- a/JUDA_iOS/JUDA/View/DrinkInfo/DrinkInfoView.swift
+++ b/JUDA_iOS/JUDA/View/DrinkInfo/DrinkInfoView.swift
@@ -235,7 +235,3 @@ struct DrinkInfoView: View {
         .toolbar(appViewModel.tabBarState, for: .tabBar)
 	}
 }
-
-#Preview {
-	DrinkInfoView()
-}

--- a/JUDA_iOS/JUDA/View/Mypage/MyPageView.swift
+++ b/JUDA_iOS/JUDA/View/Mypage/MyPageView.swift
@@ -22,7 +22,7 @@ struct MyPageView: View {
                     UnauthenticatedMypageView()
                 }
             }
-            .navigationBarBackButtonHidden()
+            .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .topBarLeading) {
                     Text("마이페이지")

--- a/JUDA_iOS/JUDA/View/Posts/NavigationPostsView.swift
+++ b/JUDA_iOS/JUDA/View/Posts/NavigationPostsView.swift
@@ -131,6 +131,7 @@ struct NavigationPostsView: View {
                 } label: {
                     Image(systemName: "chevron.left")
                 }
+                .disabled(authViewModel.isShowLoginDialog)
             }
             ToolbarItem(placement: .principal) {
                 Text(titleText)

--- a/JUDA_iOS/JUDA/View/Posts/NavigationPostsView.swift
+++ b/JUDA_iOS/JUDA/View/Posts/NavigationPostsView.swift
@@ -65,9 +65,9 @@ struct NavigationPostsView: View {
                             }
                         }
                     }
-                    .tabViewStyle(.page(indexDisplayMode: .never))
-                    .ignoresSafeArea()
                 }
+                .tabViewStyle(.page(indexDisplayMode: .never))
+                .ignoresSafeArea()
             }
             
             if authViewModel.isShowLoginDialog {


### PR DESCRIPTION
## 개요 (이슈 번호 및 요약)
- #178 

## 변경 사항 (작업 내용)
### NavigationPostsView의 하단 잘림 현상
```swift
.tabViewStyle(.page(indexDisplayMode: .never))
.ignoresSafeArea()
```
코드 위치 변경 (TabView 안 -> TabView 밖)

### CustomDialog 띄울 때 특정 동작 제한
- 다이얼로그가 나타나는 뷰의 ToolBarItem disabled
- 다이얼로그가 나타날 때, 제스쳐를 통한 Navigation Back 동작 막기

## 스크린샷

## 특이사항 (트러블 슈팅 과정 및 참고 자료 등)
### NavigationPostView

🥂 **문제**
ScrollView 내의 PostsGrid가 잘려서 보임

🥂 **원인**
<img width="523" alt="스크린샷 2024-04-23 오후 12 27 48" src="https://github.com/JUDA-Hrmi/JUDA/assets/120158212/e958ea31-d91a-4f81-a6d7-cc0fd634a3a9">

view hierarchy 확인 결과 하단에 UITabBar 발견
하단에 잘린 부분을 클릭해보니 TabView의 선택된 인덱스 값이 변경됨
코드를 확인해보니 tabViewStyle의 코드 위치가 잘못되어 탭 뷰 버튼이 사라지지 않았음

🥂 **해결**
tabViewStyle과 ignoreSafeArea 코드를 올바른 위치로 옮겨줌

<br></br>

### LoginDialog 관련 오류

🥂 **문제와 원인**
로그인 다이얼로그가 뷰에 띄워진 상태에서 Navigation을 Back버튼을 누르거나 제스쳐를 통한 Back 이 이루어졌을 경우,
Disappear에서 isShowDialog를 false로 바꿔주기 전에 이전 화면이 나타나게 되면서 이전 화면에도 로그인 다이얼로그가 나타나는 현상이 발생

🥂 **해결**
- #178 

<br></br>