### PR TITLE
[Refactoring] 회원가입 및 닉네임 변경 시 로직 수정

### DIFF
--- a/JUDA_iOS/JUDA.xcodeproj/project.pbxproj
+++ b/JUDA_iOS/JUDA.xcodeproj/project.pbxproj
@@ -61,9 +61,7 @@
 		09BCC15A2B7C8CD300FF4D1B /* IdentityVerificationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09BCC1592B7C8CD300FF4D1B /* IdentityVerificationView.swift */; };
 		09BCC15F2B7CFC7E00FF4D1B /* TermsAndVerificationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09BCC15E2B7CFC7E00FF4D1B /* TermsAndVerificationView.swift */; };
 		09C7C9AF2B8DB57E00F62617 /* NavigationRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09C7C9AE2B8DB57E00F62617 /* NavigationRouter.swift */; };
-		09E3B6E82BC51396001BC529 /* DrinkLoading.json in Resources */ = {isa = PBXBuildFile; fileRef = 09E3B6E72BC51396001BC529 /* DrinkLoading.json */; };
-		09E3B6EB2BC5139F001BC529 /* APIKEYS.plist in Resources */ = {isa = PBXBuildFile; fileRef = 09E3B6E92BC5139F001BC529 /* APIKEYS.plist */; };
-		09E3B6EC2BC5139F001BC529 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 09E3B6EA2BC5139F001BC529 /* GoogleService-Info.plist */; };
+		09E3B6E82BC51396001BC529 /* (null) in Resources */ = {isa = PBXBuildFile; };
 		09F3BD9C2BA9EAE90087E5FC /* Lottie in Frameworks */ = {isa = PBXBuildFile; productRef = 09F3BD9B2BA9EAE90087E5FC /* Lottie */; };
 		09F869932B68E36800A56A4C /* Formatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09F869922B68E36800A56A4C /* Formatter.swift */; };
 		09F869962B68E46500A56A4C /* DrinkDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09F869952B68E46500A56A4C /* DrinkDetailView.swift */; };
@@ -90,17 +88,15 @@
 		2C63DD672B67EB1B00770E3A /* RecordView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C63DD662B67EB1B00770E3A /* RecordView.swift */; };
 		2C69CDAC2B9DF61600F70F80 /* RecordViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C69CDAB2B9DF61600F70F80 /* RecordViewModel.swift */; };
 		2C7FD5522B848EEF00169512 /* Post.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C7FD5512B848EEF00169512 /* Post.swift */; };
-		2C9707442BC5144F001D57D5 /* APIKEYS.plist in Resources */ = {isa = PBXBuildFile; fileRef = 2C9707422BC5144F001D57D5 /* APIKEYS.plist */; };
-		2C9707452BC5144F001D57D5 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 2C9707432BC5144F001D57D5 /* GoogleService-Info.plist */; };
 		2C9707472BC51486001D57D5 /* DrinkLoading.json in Resources */ = {isa = PBXBuildFile; fileRef = 2C9707462BC51486001D57D5 /* DrinkLoading.json */; };
+		2C9743E12BE6801200694EE9 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 2C9743DF2BE6801200694EE9 /* GoogleService-Info.plist */; };
+		2C9743E22BE6801200694EE9 /* APIKEYS.plist in Resources */ = {isa = PBXBuildFile; fileRef = 2C9743E02BE6801200694EE9 /* APIKEYS.plist */; };
 		2CACB53C2B99BAC500DD6DCE /* FireStorageService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CACB53B2B99BAC500DD6DCE /* FireStorageService.swift */; };
 		7B0A8BC52B8C163E00740E61 /* Report.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B0A8BC42B8C163E00740E61 /* Report.swift */; };
 		7B0A8BCD2B8CA7E900740E61 /* PostSearchList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B0A8BCC2B8CA7E900740E61 /* PostSearchList.swift */; };
 		7B0A8BCF2B8CA8C300740E61 /* PostSearchListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B0A8BCE2B8CA8C300740E61 /* PostSearchListCell.swift */; };
 		7B5174922B69EAB300915793 /* NavigationPostsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B5174912B69EAB300915793 /* NavigationPostsView.swift */; };
 		7B56AE172BA66C8200C47F3C /* FirebaseFunctions in Frameworks */ = {isa = PBXBuildFile; productRef = 7B56AE162BA66C8200C47F3C /* FirebaseFunctions */; };
-		7B648FC52BC52969009010DC /* APIKEYS.plist in Resources */ = {isa = PBXBuildFile; fileRef = 7B648FC32BC52969009010DC /* APIKEYS.plist */; };
-		7B648FC62BC52969009010DC /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 7B648FC42BC52969009010DC /* GoogleService-Info.plist */; };
 		7B6D76A72B677A8F00601B55 /* Button.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B6D76A62B677A8F00601B55 /* Button.swift */; };
 		7B6D76AB2B67CE3D00601B55 /* PostDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B6D76AA2B67CE3D00601B55 /* PostDetailView.swift */; };
 		7B6D76AF2B67CFC900601B55 /* PostInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B6D76AE2B67CFC900601B55 /* PostInfo.swift */; };
@@ -122,7 +118,6 @@
 		7BBDFF702B6B90EB0036FB8B /* PostGrid.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B6D76B62B68972000601B55 /* PostGrid.swift */; };
 		7BBDFF722B6B912C0036FB8B /* TabItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C63DD512B676E1000770E3A /* TabItem.swift */; };
 		7BBDFF732B6B912C0036FB8B /* DrinkInfoSegment.swift in Sources */ = {isa = PBXBuildFile; fileRef = B16EB85B2B63859800E920A3 /* DrinkInfoSegment.swift */; };
-		7BD26B482BADC00F0036EB91 /* DrinkLoading.json in Resources */ = {isa = PBXBuildFile; fileRef = 7BD26B472BADC00F0036EB91 /* DrinkLoading.json */; };
 		7BE14B952B84733900C1F6C3 /* Drink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BE14B942B84733900C1F6C3 /* Drink.swift */; };
 		7BE14B972B84767000C1F6C3 /* DrinkUploadViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BE14B962B84767000C1F6C3 /* DrinkUploadViewModel.swift */; };
 		AC110B572B69658C005390BB /* ChangeUserNameView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC110B562B69658C005390BB /* ChangeUserNameView.swift */; };
@@ -228,8 +223,6 @@
 		09BCC1592B7C8CD300FF4D1B /* IdentityVerificationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentityVerificationView.swift; sourceTree = "<group>"; };
 		09BCC15E2B7CFC7E00FF4D1B /* TermsAndVerificationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TermsAndVerificationView.swift; sourceTree = "<group>"; };
 		09C7C9AE2B8DB57E00F62617 /* NavigationRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationRouter.swift; sourceTree = "<group>"; };
-		09E3B6E92BC5139F001BC529 /* APIKEYS.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = APIKEYS.plist; path = "../../../흐르미/APIKEYS.plist"; sourceTree = "<group>"; };
-		09E3B6EA2BC5139F001BC529 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "../../../흐르미/GoogleService-Info.plist"; sourceTree = "<group>"; };
 		09F869922B68E36800A56A4C /* Formatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Formatter.swift; sourceTree = "<group>"; };
 		09F869952B68E46500A56A4C /* DrinkDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrinkDetailView.swift; sourceTree = "<group>"; };
 		09F869972B68E48400A56A4C /* DrinkDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrinkDetails.swift; sourceTree = "<group>"; };
@@ -256,16 +249,14 @@
 		2C63DD662B67EB1B00770E3A /* RecordView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordView.swift; sourceTree = "<group>"; };
 		2C69CDAB2B9DF61600F70F80 /* RecordViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordViewModel.swift; sourceTree = "<group>"; };
 		2C7FD5512B848EEF00169512 /* Post.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Post.swift; sourceTree = "<group>"; };
-		2C9707422BC5144F001D57D5 /* APIKEYS.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = APIKEYS.plist; path = "../../../HrMi-JUDA/APIKEY & plist.plist/APIKEYS.plist"; sourceTree = "<group>"; };
-		2C9707432BC5144F001D57D5 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "../../../HrMi-JUDA/APIKEY & plist.plist/GoogleService-Info.plist"; sourceTree = "<group>"; };
 		2C9707462BC51486001D57D5 /* DrinkLoading.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = DrinkLoading.json; path = "../../../../../HrMi-JUDA/Lottie/DrinkLoading.json"; sourceTree = "<group>"; };
+		2C9743DF2BE6801200694EE9 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "../../../HrMi-JUDA/APIKEY & plist.plist/GoogleService-Info.plist"; sourceTree = "<group>"; };
+		2C9743E02BE6801200694EE9 /* APIKEYS.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = APIKEYS.plist; path = "../../../HrMi-JUDA/APIKEY & plist.plist/APIKEYS.plist"; sourceTree = "<group>"; };
 		2CACB53B2B99BAC500DD6DCE /* FireStorageService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FireStorageService.swift; sourceTree = "<group>"; };
 		7B0A8BC42B8C163E00740E61 /* Report.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Report.swift; sourceTree = "<group>"; };
 		7B0A8BCC2B8CA7E900740E61 /* PostSearchList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostSearchList.swift; sourceTree = "<group>"; };
 		7B0A8BCE2B8CA8C300740E61 /* PostSearchListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostSearchListCell.swift; sourceTree = "<group>"; };
 		7B5174912B69EAB300915793 /* NavigationPostsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationPostsView.swift; sourceTree = "<group>"; };
-		7B648FC32BC52969009010DC /* APIKEYS.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = APIKEYS.plist; path = ../../../../../../JUDA_file/APIKEYS.plist; sourceTree = "<group>"; };
-		7B648FC42BC52969009010DC /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "../../../../../../JUDA_file/GoogleService-Info.plist"; sourceTree = "<group>"; };
 		7B6D76A62B677A8F00601B55 /* Button.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Button.swift; sourceTree = "<group>"; };
 		7B6D76AA2B67CE3D00601B55 /* PostDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostDetailView.swift; sourceTree = "<group>"; };
 		7B6D76AE2B67CFC900601B55 /* PostInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostInfo.swift; sourceTree = "<group>"; };
@@ -283,7 +274,6 @@
 		7B92656C2B692F0700840095 /* PostReportContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostReportContent.swift; sourceTree = "<group>"; };
 		7B92656E2B69303F00840095 /* PostReportButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostReportButton.swift; sourceTree = "<group>"; };
 		7B9265702B6941D000840095 /* PostReportToolbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostReportToolbar.swift; sourceTree = "<group>"; };
-		7BD26B472BADC00F0036EB91 /* DrinkLoading.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = DrinkLoading.json; path = ../../../../../../../../JUDA_file/Lottie/DrinkLoading.json; sourceTree = "<group>"; };
 		7BE14B942B84733900C1F6C3 /* Drink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Drink.swift; sourceTree = "<group>"; };
 		7BE14B962B84767000C1F6C3 /* DrinkUploadViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrinkUploadViewModel.swift; sourceTree = "<group>"; };
 		AC110B562B69658C005390BB /* ChangeUserNameView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeUserNameView.swift; sourceTree = "<group>"; };
@@ -445,13 +435,6 @@
 			path = Lottie;
 			sourceTree = "<group>";
 		};
-		09E3B6E62BC51344001BC529 /* Recovered References */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			name = "Recovered References";
-			sourceTree = "<group>";
-		};
 		09F869942B68E44A00A56A4C /* DrinkDetail */ = {
 			isa = PBXGroup;
 			children = (
@@ -473,13 +456,6 @@
 				2C63DD512B676E1000770E3A /* TabItem.swift */,
 			);
 			path = ContentView;
-			sourceTree = "<group>";
-		};
-		2C9707412BC513BE001D57D5 /* Recovered References */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			name = "Recovered References";
 			sourceTree = "<group>";
 		};
 		7B0A8BCA2B8CA77400740E61 /* PostDetail */ = {
@@ -511,13 +487,6 @@
 			children = (
 			);
 			name = Frameworks;
-			sourceTree = "<group>";
-		};
-		7B648FC22BC528F7009010DC /* Recovered References */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			name = "Recovered References";
 			sourceTree = "<group>";
 		};
 		B121A5652B5F8D2000667D42 /* Resource */ = {
@@ -581,7 +550,6 @@
 			children = (
 				B1B8FE7B2B5EA9D900921BBE /* JUDA */,
 				7B56AE152BA66C8200C47F3C /* Frameworks */,
-				2C9707412BC513BE001D57D5 /* Recovered References */,
 			);
 			sourceTree = "<group>";
 		};
@@ -598,8 +566,8 @@
 				B1B8FE802B5EA9DA00921BBE /* Assets.xcassets */,
 				B1B8FE8C2B5EAAAB00921BBE /* Colors.xcassets */,
 				B121A56F2B5F8DA100667D42 /* Info.plist */,
-				09E3B6E92BC5139F001BC529 /* APIKEYS.plist */,
-				09E3B6EA2BC5139F001BC529 /* GoogleService-Info.plist */,
+				2C9743E02BE6801200694EE9 /* APIKEYS.plist */,
+				2C9743DF2BE6801200694EE9 /* GoogleService-Info.plist */,
 				B1B8FE822B5EA9DA00921BBE /* Preview Content */,
 			);
 			path = JUDA;
@@ -867,8 +835,7 @@
 			};
 			buildConfigurationList = B1B8FE742B5EA9D900921BBE /* Build configuration list for PBXProject "JUDA" */;
 			compatibilityVersion = "Xcode 14.0";
-			
-      mentRegion = ko;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
@@ -903,20 +870,19 @@
 				B1B8FE8D2B5EAAAB00921BBE /* Colors.xcassets in Resources */,
 				B121A5732B5F910900667D42 /* Pretendard-Bold.otf in Resources */,
 				09BCC14F2B7C7E2900FF4D1B /* Loading.json in Resources */,
-				09E3B6E82BC51396001BC529 /* DrinkLoading.json in Resources */,
+				09E3B6E82BC51396001BC529 /* (null) in Resources */,
 				B1B8FE842B5EA9DA00921BBE /* Preview Assets.xcassets in Resources */,
 				B121A5782B5F911A00667D42 /* Pretendard-Thin.otf in Resources */,
 				B121A5772B5F911900667D42 /* Pretendard-SemiBold.otf in Resources */,
 				09BCC1532B7C7E2900FF4D1B /* Snow.json in Resources */,
+				2C9743E12BE6801200694EE9 /* GoogleService-Info.plist in Resources */,
 				09BCC1542B7C7E2900FF4D1B /* Clouds.json in Resources */,
-				09E3B6EC2BC5139F001BC529 /* GoogleService-Info.plist in Resources */,
 				B121A5742B5F910B00667D42 /* Pretendard-Light.otf in Resources */,
 				09BCC1522B7C7E2900FF4D1B /* Rain.json in Resources */,
-				2C9707452BC5144F001D57D5 /* GoogleService-Info.plist in Resources */,
 				B121A5762B5F911700667D42 /* Pretendard-Regular.otf in Resources */,
 				B1B8FE812B5EA9DA00921BBE /* Assets.xcassets in Resources */,
 				B121A5752B5F911500667D42 /* Pretendard-Medium.otf in Resources */,
-				09E3B6EB2BC5139F001BC529 /* APIKEYS.plist in Resources */,
+				2C9743E22BE6801200694EE9 /* APIKEYS.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/JUDA_iOS/JUDA.xcodeproj/xcshareddata/xcschemes/JUDA.xcscheme
+++ b/JUDA_iOS/JUDA.xcodeproj/xcshareddata/xcschemes/JUDA.xcscheme
@@ -42,8 +42,7 @@
       allowLocationSimulation = "YES">
       <PathRunnable
          runnableDebuggingMode = "0"
-         FilePath = "/Users/minjaekim/Library/Developer/Xcode/DerivedData/JUDA-gzjyaxsluhlruncajghxttycvogn/Build/Products/Debug-iphoneos/JUDA.app">
-         BundleIdentifier = "com.hrmi.juda"
+         FilePath = "/Users/chung-inseon/Library/Developer/Xcode/DerivedData/JUDA-alivsugfiknafgevihdwjnmwgsbv/Build/Products/Debug-iphoneos/JUDA.app">
       </PathRunnable>
       <MacroExpansion>
          <BuildableReference

--- a/JUDA_iOS/JUDA/Resource/Constants.swift
+++ b/JUDA_iOS/JUDA/Resource/Constants.swift
@@ -193,3 +193,11 @@ enum WhereUsedPostGridContent {
     case myPage
     case main
 }
+
+// 닉네임 변경 & 생성 시 조건에 대한 enum
+enum NickNameChange {
+    case invalidLength
+    case aleadyUsing
+    case completed
+    case userNotFound
+}

--- a/JUDA_iOS/JUDA/View/LogIn/ProfileSettingView.swift
+++ b/JUDA_iOS/JUDA/View/LogIn/ProfileSettingView.swift
@@ -26,12 +26,13 @@ struct ProfileSettingView: View {
     @State private var birthDate: String = ""
     @State private var selectedGender: Gender?
     
+    // 닉네임 형식을 만족하는지 판별하기 위한 상태 프로퍼티
+    @State private var isValidNameFormat: Bool = false
+    // 생년월일 형식을 만족하는지 판별하기 위한 상태 프로퍼티
+    @State private var isValidBirthFormat: Bool = false
+    
     // 이미지 가져오다가 에러나면 띄워줄 alert
     @State private var isShowAlertDialog = false
-    
-    var nameReference: Bool {
-        focusedField == .name && (name.count <= 1 || name.count > 10)
-    }
 
     // 상위 뷰 체인지를 위함
     @Binding var viewType: TermsOrVerification
@@ -109,6 +110,9 @@ struct ProfileSettingView: View {
                             .keyboardType(.default)
                             .textInputAutocapitalization(.never)
                             .autocorrectionDisabled() // 자동 수정 비활성화
+                            .onChange(of: name) { _ in
+                                isValidNameFormat = (name.count >= 2) && (name.count <= 10)
+                            }
                             Spacer()
                             // 텍스트 한번에 지우는 xmark 버튼
                             if !name.isEmpty && focusedField == .name {
@@ -127,7 +131,7 @@ struct ProfileSettingView: View {
                         // 닉네임 만족 기준
                         Text("닉네임을 2자~10자 이내로 적어주세요.")
                             .font(.light14)
-                            .foregroundStyle(nameReference ? .mainAccent01 : .clear)
+                            .foregroundStyle(name.isEmpty || isValidNameFormat ? .clear : .mainAccent01)
                             .frame(maxWidth: .infinity, alignment: .leading)
                     }
                     // 생일 + 성별
@@ -203,14 +207,17 @@ struct ProfileSettingView: View {
                 .buttonStyle(.borderedProminent)
                 .tint(.mainAccent03)
                 // 모든 정보 입력 시, 버튼 보이도록
-                .disabled(name.isEmpty || birthDate.isEmpty || selectedGender == nil)
+                .disabled(!isValidNameFormat || !isValidBirthFormat || selectedGender == nil)
                 .padding(.bottom, 10)
             }
             .padding(.horizontal, 20)
             // 생일 6글자 치면 끝
             .onChange(of: birthDate) { _ in
                 if birthDate.count == 6 {
+                    isValidBirthFormat = true
                     focusedField = nil
+                } else {
+                    isValidBirthFormat = false
                 }
             }
             // 텍스트필드에서 엔터 시, 이동

--- a/JUDA_iOS/JUDA/View/Mypage/MypageDetail/ChangeUserNameView.swift
+++ b/JUDA_iOS/JUDA/View/Mypage/MypageDetail/ChangeUserNameView.swift
@@ -34,6 +34,7 @@ struct ChangeUserNameView: View {
                 .textInputAutocapitalization(.never)
                 .autocorrectionDisabled() // 자동 수정 비활성화
                 .onChange(of: userChangeNickName) { _ in
+                    userChangeNickName = String(userChangeNickName.prefix(10))
                     isCompleted = authViewModel.isChangeUserName(changeName: userChangeNickName)
                 }
                 Spacer()
@@ -53,20 +54,26 @@ struct ChangeUserNameView: View {
             .background(.gray05)
             .clipShape(.rect(cornerRadius: 10))
             // 유저 닉네임 만족 기준
-            if isFocused {
-                if userChangeNickName.count <= 1 || userChangeNickName.count > 10 {
-                    Text("닉네임을 2자~10자 이내로 적어주세요.")
-                        .font(.light14)
-                        .foregroundStyle(.mainAccent01)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                }
-                if userChangeNickName == authViewModel.currentUser?.userField.name {
-                    Text("현재 사용하고 있는 닉네임입니다.")
-                        .font(.light14)
-                        .foregroundStyle(.mainAccent01)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                }
+            if !userChangeNickName.isEmpty && 
+                (userChangeNickName.count <= 1 || userChangeNickName.count > 10) {
+                Text("닉네임을 2자~10자 이내로 적어주세요.")
+                    .font(.light14)
+                    .foregroundStyle(.mainAccent01)
+                    .frame(maxWidth: .infinity, alignment: .leading)
             }
+            if userChangeNickName == authViewModel.currentUser?.userField.name {
+                Text("현재 사용하고 있는 닉네임입니다.")
+                    .font(.light14)
+                    .foregroundStyle(.mainAccent01)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            if userChangeNickName.contains(" ") {
+                Text("공백은 사용이 불가합니다.")
+                    .font(.light14)
+                    .foregroundStyle(.mainAccent01)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            
             // spacer 대용 (키보드 숨기기 onTapGesture 영역)
             Rectangle()
                 .fill(.background)

--- a/JUDA_iOS/JUDA/ViewModel/Auth/AuthViewModel.swift
+++ b/JUDA_iOS/JUDA/ViewModel/Auth/AuthViewModel.swift
@@ -29,6 +29,7 @@ final class AuthViewModel: ObservableObject {
     // Error
     @Published var showError: Bool = false
     @Published var errorMessage: String = ""
+    @Published var nicknameState: NickNameChange = .invalidLength
     // 로그인 다이얼로그
     @Published var isShowLoginDialog: Bool = false
     // Nonce : 암호와된 임의의 난수
@@ -120,11 +121,18 @@ final class AuthViewModel: ObservableObject {
     
     // MyPage / Setting 에서 사용
     // 유저 닉네임 수정 시, 2글자 이상 10글자 이하 && 기존 닉네임과 같은지 체크
-    func isChangeUserName(changeName: String) -> Bool {
-        guard let user = currentUser else {
-            return false
+    func isChangeUserName(changeName: String) {
+        if changeName.count < 2 || changeName.count > 10 { // 닉네임 길이
+            nicknameState = .invalidLength
+        } else {
+            nicknameState = .completed
         }
-        return changeName.count >= 2 && changeName.count <= 10 && user.userField.name != changeName && user.userField.name.contains(" ")
+        
+        if let user = currentUser { // 로그인한 유저의 닉네임 변경 시, 기존 닉네임과 동일한지
+            if user.userField.name == changeName {
+                nicknameState = .aleadyUsing
+            }
+        }
     }
     
     // 유저 프로필 사진 변경 시, 사용되는 메서드

--- a/JUDA_iOS/JUDA/ViewModel/Auth/AuthViewModel.swift
+++ b/JUDA_iOS/JUDA/ViewModel/Auth/AuthViewModel.swift
@@ -124,7 +124,7 @@ final class AuthViewModel: ObservableObject {
         guard let user = currentUser else {
             return false
         }
-        return changeName.count >= 2 && changeName.count <= 10 && user.userField.name != changeName
+        return changeName.count >= 2 && changeName.count <= 10 && user.userField.name != changeName && user.userField.name.contains(" ")
     }
     
     // 유저 프로필 사진 변경 시, 사용되는 메서드


### PR DESCRIPTION
## 개요 (이슈 번호 및 요약)
- #182 

## 변경 사항 (작업 내용)
닉네임
- 공백 입력 불가
- 10자 입력 제한
- 2~10자 기준, 기존 닉네임 사용 등 기준 미충족 시 변경(생성) 불가

생년월일
- 6자 입력 제한
- 날짜 포맷 충족 여부 판별
- 현재 날짜보다 앞선 날짜인지 판별
- 기준 미충족 시 생성 불가

## 스크린샷

## 특이사항 (트러블 슈팅 과정 및 참고 자료 등)

닉네임 생년월일에 대한 유효성 판별하는 코드를 onchange에 넣어뒀는데,
입력값이 바뀔 때마다 판별해도 괜찮나..? 라는 생각이 드네요... 😥
